### PR TITLE
Feature/add viewbinder debug mode

### DIFF
--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewBinder.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewBinder.java
@@ -73,9 +73,6 @@ public class ViewBinder implements IViewBinder {
 
     private IImageLoader mImageLoader = IImageLoader.nullImageLoader;
 
-    public ViewBinder() {
-        init();
-    }
 
     public ViewBinder(Context ctx) {
         setContext(ctx);

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewBinder.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewBinder.java
@@ -12,9 +12,9 @@ import android.view.ViewGroup;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -64,9 +64,9 @@ public class ViewBinder implements IViewBinder {
 
     private TextSpecificationBinder mBinder;
 
-    private Map<View, List<IBindingAssociationEngine>> mBoundViews = new HashMap<View, List<IBindingAssociationEngine>>();
+    private Map<View, List<IBindingAssociationEngine>> mBoundViews = new ConcurrentHashMap<>();
 
-    private Map<View, String> mLazyBoundViews = new HashMap<>();
+    private Map<View, String> mLazyBoundViews = new ConcurrentHashMap<>();
 
     @Getter
     private IFontManager mFontManager;

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewBinder.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewBinder.java
@@ -105,12 +105,16 @@ public class ViewBinder implements IViewBinder {
 
     @Override
     public void setContext(Context ctx) {
-        if (mContext != null) {
-            mContext.clear();
-        }
+        if (getContext() != ctx) {
+            getLogger().verbose("old context = " + mContext + ", new context = " + ctx);
 
-        if (ctx != null) {
-            mContext = new WeakReference<>(ctx);
+            if (mContext != null) {
+                mContext.clear();
+            }
+
+            if (ctx != null) {
+                mContext = new WeakReference<>(ctx);
+            }
         }
     }
 
@@ -220,7 +224,7 @@ public class ViewBinder implements IViewBinder {
             return;
         }
 
-        mLogger.verbose("clearBindingsFor view = " + view);
+        mLogger.verbose("clearBindingsFor view = " + view + ", current bound views size = " + mBoundViews.size());
 
         if (mLazyBoundViews.containsKey(view)) {
             mLazyBoundViews.remove(view);
@@ -242,6 +246,8 @@ public class ViewBinder implements IViewBinder {
 
         bindings.clear();
         mBoundViews.remove(view);
+
+        mLogger.verbose("clearBindingsFor finished for view = " + view + ", remaining bound views size = " + mBoundViews.size());
     }
 
     @Override

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewBinder.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewBinder.java
@@ -111,6 +111,17 @@ public class ViewBinder implements IViewBinder {
     }
 
     @Override
+    public void disposeOf(Context ctx) {
+        getLogger().verbose("disposing of context = " + ctx);
+
+        for (View view : mBoundViews.keySet()) {
+            if (view.getContext() == ctx) {
+                clearBindingsFor(view); //it doesn't go deep because we're gonna get all of them anyway
+            }
+        }
+    }
+
+    @Override
     public void setContext(Context ctx) {
         if (getContext() != ctx) {
             getLogger().verbose("old context = " + mContext + ", new context = " + ctx);

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewBinder.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewBinder.java
@@ -73,6 +73,8 @@ public class ViewBinder implements IViewBinder {
 
     private IImageLoader mImageLoader = IImageLoader.nullImageLoader;
 
+    @Getter
+    private boolean mDebugMode;
 
     public ViewBinder(Context ctx) {
         setContext(ctx);
@@ -101,6 +103,11 @@ public class ViewBinder implements IViewBinder {
         setFontManager(new FontManager(getLogger()));
 
         registerDefaultConverters();
+    }
+
+    @Override
+    public void setDebug(boolean debugMode) {
+        mDebugMode = debugMode;
     }
 
     @Override
@@ -248,6 +255,15 @@ public class ViewBinder implements IViewBinder {
         mBoundViews.remove(view);
 
         mLogger.verbose("clearBindingsFor finished for view = " + view + ", remaining bound views size = " + mBoundViews.size());
+
+        if (isDebugMode()) {
+            for (View remainingview : mBoundViews.keySet()) {
+                if (remainingview.getContext() == view.getContext()) {
+                    mLogger.verbose(
+                            "clearBindingsFor found another remaining view with the same context as " + view + ", context = " + view.getContext() + ", found remaining view = " + remainingview);
+                }
+            }
+        }
     }
 
     @Override

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/android/BoundActivityDelegate.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/android/BoundActivityDelegate.java
@@ -203,7 +203,7 @@ public class BoundActivityDelegate implements IActivityLifecycle, IBoundActivity
                 && boundActivityRef instanceof IBindableView
                 && boundActivityRef.getWindow() != null
                 && boundActivityRef.getWindow().getDecorView() != null) {
-            getViewBinder().clearBindingForViewAndChildren(getBoundActivity().getWindow().getDecorView().getRootView());
+            getViewBinder().clearBindingForViewAndChildren(getBoundActivity().getWindow().getDecorView());
             getViewBinder().disposeOf(mBoundActivity.get());
         }
 

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/android/BoundActivityDelegate.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/android/BoundActivityDelegate.java
@@ -204,6 +204,7 @@ public class BoundActivityDelegate implements IActivityLifecycle, IBoundActivity
                 && boundActivityRef.getWindow() != null
                 && boundActivityRef.getWindow().getDecorView() != null) {
             getViewBinder().clearBindingForViewAndChildren(getBoundActivity().getWindow().getDecorView().getRootView());
+            getViewBinder().disposeOf(mBoundActivity.get());
         }
 
         if (getViewModels() != null) {

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/android/BoundFragmentDelegate.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/android/BoundFragmentDelegate.java
@@ -256,7 +256,7 @@ public class BoundFragmentDelegate
                 && getViewBinder() != null
                 && boundActivityRef.getWindow() != null
                 && boundActivityRef.getWindow().getDecorView() != null) {
-            getViewBinder().clearBindingForViewAndChildren(getBoundActivity().getWindow().getDecorView().getRootView());
+            getViewBinder().clearBindingForViewAndChildren(getBoundActivity().getWindow().getDecorView());
         }
 
         if (getViewModels() != null) {

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/interfaces/IViewBinder.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/interfaces/IViewBinder.java
@@ -50,4 +50,6 @@ public interface IViewBinder extends IResourceRegistry, IValueConverterRegistry,
     void setContext(Context context);
 
     IFontManager getFontManager();
+
+    void setDebug(boolean debugMode);
 }

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/interfaces/IViewBinder.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/interfaces/IViewBinder.java
@@ -52,4 +52,6 @@ public interface IViewBinder extends IResourceRegistry, IValueConverterRegistry,
     IFontManager getFontManager();
 
     void setDebug(boolean debugMode);
+
+    void disposeOf(Context context);
 }

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/ExampleApplication.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/ExampleApplication.java
@@ -1,10 +1,28 @@
 package solutions.alterego.androidbound.example;
 
+import com.alterego.advancedandroidlogger.interfaces.IAndroidLogger;
 import com.squareup.leakcanary.LeakCanary;
 
 import android.app.Application;
+import android.graphics.Typeface;
 
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import solutions.alterego.androidbound.ViewBinder;
+import solutions.alterego.androidbound.example.imageloader.UILImageLoader;
+import solutions.alterego.androidbound.example.util.AdvancedAndroidLoggerAdapter;
+import solutions.alterego.androidbound.example.util.CustomValueConverters;
+import solutions.alterego.androidbound.interfaces.IViewBinder;
+
+@Accessors(prefix="m")
 public class ExampleApplication extends Application {
+
+    public static final String LOGGING_TAG = "TEST_APP_VIEWBINDER";
+
+    private static final IAndroidLogger.LoggingLevel LOGGING_LEVEL = IAndroidLogger.LoggingLevel.VERBOSE;
+
+    @Getter
+    private static IViewBinder mViewBinder;
 
     @Override
     public void onCreate() {
@@ -17,5 +35,13 @@ public class ExampleApplication extends Application {
         }
 
         LeakCanary.install(this);
+
+        mViewBinder = new ViewBinder(this, new AdvancedAndroidLoggerAdapter(LOGGING_TAG, LOGGING_LEVEL));
+        mViewBinder.setImageLoader(new UILImageLoader(this, null));
+        mViewBinder.getFontManager().setDefaultFont(Typeface.createFromAsset(getAssets(), "Roboto-Regular.ttf"));
+        mViewBinder.getFontManager().registerFont("light", Typeface.createFromAsset(getAssets(), "Roboto-Light.ttf"));
+        mViewBinder.getFontManager().registerFont("italic", Typeface.createFromAsset(getAssets(), "Roboto-Italic.ttf"));
+        mViewBinder.getFontManager().registerFont("bold", Typeface.createFromAsset(getAssets(), "Roboto-Bold.ttf"));
+        CustomValueConverters customValueConverters = new CustomValueConverters(this, mViewBinder);
     }
 }

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/ExampleApplication.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/ExampleApplication.java
@@ -37,6 +37,7 @@ public class ExampleApplication extends Application {
         LeakCanary.install(this);
 
         mViewBinder = new ViewBinder(this, new AdvancedAndroidLoggerAdapter(LOGGING_TAG, LOGGING_LEVEL));
+        mViewBinder.setDebug(true); //TODO for testing!
         mViewBinder.setImageLoader(new UILImageLoader(this, null));
         mViewBinder.getFontManager().setDefaultFont(Typeface.createFromAsset(getAssets(), "Roboto-Regular.ttf"));
         mViewBinder.getFontManager().registerFont("light", Typeface.createFromAsset(getAssets(), "Roboto-Light.ttf"));

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/ExampleApplication.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/ExampleApplication.java
@@ -8,10 +8,12 @@ import android.graphics.Typeface;
 
 import lombok.Getter;
 import lombok.experimental.Accessors;
+import solutions.alterego.androidbound.NullLogger;
 import solutions.alterego.androidbound.ViewBinder;
 import solutions.alterego.androidbound.example.imageloader.UILImageLoader;
 import solutions.alterego.androidbound.example.util.AdvancedAndroidLoggerAdapter;
 import solutions.alterego.androidbound.example.util.CustomValueConverters;
+import solutions.alterego.androidbound.interfaces.ILogger;
 import solutions.alterego.androidbound.interfaces.IViewBinder;
 
 @Accessors(prefix="m")
@@ -35,9 +37,9 @@ public class ExampleApplication extends Application {
         }
 
         LeakCanary.install(this);
-
-        mViewBinder = new ViewBinder(this, new AdvancedAndroidLoggerAdapter(LOGGING_TAG, LOGGING_LEVEL));
-        mViewBinder.setDebug(true); //TODO for testing!
+        ILogger logger = new AdvancedAndroidLoggerAdapter(LOGGING_TAG, LOGGING_LEVEL); //use for testing
+        mViewBinder = new ViewBinder(this, NullLogger.instance);
+//        mViewBinder.setDebug(true); //use for testing!
         mViewBinder.setImageLoader(new UILImageLoader(this, null));
         mViewBinder.getFontManager().setDefaultFont(Typeface.createFromAsset(getAssets(), "Roboto-Regular.ttf"));
         mViewBinder.getFontManager().registerFont("light", Typeface.createFromAsset(getAssets(), "Roboto-Light.ttf"));

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/ListItemDetailActivity.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/ListItemDetailActivity.java
@@ -4,9 +4,7 @@ import com.alterego.advancedandroidlogger.interfaces.IAndroidLogger;
 
 import android.os.Bundle;
 
-import solutions.alterego.androidbound.ViewBinder;
 import solutions.alterego.androidbound.android.BindingAppCompatActivity;
-import solutions.alterego.androidbound.example.imageloader.UILImageLoader;
 import solutions.alterego.androidbound.example.util.AdvancedAndroidLoggerAdapter;
 import solutions.alterego.androidbound.example.viewmodels.ListItemDetailActivityViewModel;
 import solutions.alterego.androidbound.interfaces.ILogger;
@@ -23,8 +21,6 @@ public class ListItemDetailActivity extends BindingAppCompatActivity {
 
     private static final IAndroidLogger.LoggingLevel LOGGING_LEVEL = IAndroidLogger.LoggingLevel.VERBOSE;
 
-    private IViewBinder mViewBinder;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -33,9 +29,7 @@ public class ListItemDetailActivity extends BindingAppCompatActivity {
         String title = getIntent().getStringExtra(EXTRA_ITEM_TITLE);
         String imageUrl = getIntent().getStringExtra(EXTRA_ITEM_IMAGE_URL);
 
-        ViewBinder viewBinder = new ViewBinder(this, logger);
-        viewBinder.setImageLoader(new UILImageLoader(this, null));
-        setViewBinder(viewBinder);
+        setLogger(logger);
 
         setContentView(R.layout.activity_item_detail, new ListItemDetailActivityViewModel(this, logger, title, imageUrl));
 
@@ -44,19 +38,11 @@ public class ListItemDetailActivity extends BindingAppCompatActivity {
 
     @Override
     public IViewBinder getViewBinder() {
-        return mViewBinder;
+        return ExampleApplication.getViewBinder();
     }
 
     @Override
     public void setViewBinder(IViewBinder viewBinder) {
-        mViewBinder = viewBinder;
     }
 
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        if (getViewBinder() != null) {
-            getViewBinder().dispose();
-        }
-    }
 }

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/ListViewActivity.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/ListViewActivity.java
@@ -5,10 +5,7 @@ import com.codemonkeylabs.fpslibrary.TinyDancer;
 
 import android.os.Bundle;
 
-import solutions.alterego.androidbound.NullLogger;
-import solutions.alterego.androidbound.ViewBinder;
 import solutions.alterego.androidbound.android.BindingAppCompatActivity;
-import solutions.alterego.androidbound.example.imageloader.UILImageLoader;
 import solutions.alterego.androidbound.example.util.AdvancedAndroidLoggerAdapter;
 import solutions.alterego.androidbound.example.viewmodels.ListViewActivityViewModel;
 import solutions.alterego.androidbound.interfaces.ILogger;
@@ -21,17 +18,13 @@ public class ListViewActivity extends BindingAppCompatActivity {
 
     private static final IAndroidLogger.LoggingLevel LOGGING_LEVEL = IAndroidLogger.LoggingLevel.VERBOSE;
 
-    private IViewBinder mViewBinder;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ILogger logger = new AdvancedAndroidLoggerAdapter(LOGGING_TAG, LOGGING_LEVEL);
         TinyDancer.create().show(this);
 
-        ViewBinder viewBinder = new ViewBinder(this, NullLogger.instance);
-        viewBinder.setImageLoader(new UILImageLoader(this, null));
-        setViewBinder(viewBinder);
+        setLogger(logger);
 
         setContentView(R.layout.activity_listview, new ListViewActivityViewModel(this, logger));
 
@@ -40,19 +33,10 @@ public class ListViewActivity extends BindingAppCompatActivity {
 
     @Override
     public IViewBinder getViewBinder() {
-        return mViewBinder;
+        return ExampleApplication.getViewBinder();
     }
 
     @Override
     public void setViewBinder(IViewBinder viewBinder) {
-        mViewBinder = viewBinder;
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        if (getViewBinder() != null) {
-            getViewBinder().dispose();
-        }
     }
 }

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/ListViewWithObjectsActivity.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/ListViewWithObjectsActivity.java
@@ -5,10 +5,7 @@ import com.codemonkeylabs.fpslibrary.TinyDancer;
 
 import android.os.Bundle;
 
-import solutions.alterego.androidbound.NullLogger;
-import solutions.alterego.androidbound.ViewBinder;
 import solutions.alterego.androidbound.android.BindingAppCompatActivity;
-import solutions.alterego.androidbound.example.imageloader.UILImageLoader;
 import solutions.alterego.androidbound.example.util.AdvancedAndroidLoggerAdapter;
 import solutions.alterego.androidbound.example.viewmodels.ListViewWithObjectsActivityViewModel;
 import solutions.alterego.androidbound.interfaces.ILogger;
@@ -20,36 +17,23 @@ public class ListViewWithObjectsActivity extends BindingAppCompatActivity {
 
     private static final IAndroidLogger.LoggingLevel LOGGING_LEVEL = IAndroidLogger.LoggingLevel.VERBOSE;
 
-    private IViewBinder mViewBinder;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ILogger logger = new AdvancedAndroidLoggerAdapter(LOGGING_TAG, LOGGING_LEVEL);
         TinyDancer.create().show(this);
 
-        ViewBinder viewBinder = new ViewBinder(this, NullLogger.instance);
-        viewBinder.setImageLoader(new UILImageLoader(this, null));
-        setViewBinder(viewBinder);
+        setLogger(logger);
 
         setContentView(R.layout.activity_listview, new ListViewWithObjectsActivityViewModel(this, logger));
     }
 
     @Override
     public IViewBinder getViewBinder() {
-        return mViewBinder;
+        return ExampleApplication.getViewBinder();
     }
 
     @Override
     public void setViewBinder(IViewBinder viewBinder) {
-        mViewBinder = viewBinder;
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        if (getViewBinder() != null) {
-            getViewBinder().dispose();
-        }
     }
 }

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/MainActivity.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/MainActivity.java
@@ -23,12 +23,14 @@ public class MainActivity extends AppCompatActivity {
 
     private ViewModel mViewModel;
 
+    private IViewBinder mViewBinder;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ILogger logger = new AdvancedAndroidLoggerAdapter(LOGGING_TAG, LOGGING_LEVEL);
 
-        IViewBinder mViewBinder = ExampleApplication.getViewBinder();
+        mViewBinder = ExampleApplication.getViewBinder();
 
         mViewBinder.getFontManager().setDefaultFont(Typeface.createFromAsset(getAssets(), "Roboto-Bold.ttf"));
         mViewBinder.getFontManager().registerFont("light", Typeface.createFromAsset(getAssets(), "Roboto-Light.ttf"));
@@ -67,5 +69,6 @@ public class MainActivity extends AppCompatActivity {
     protected void onDestroy() {
         super.onDestroy();
         mViewModel.dispose();
+        mViewBinder.disposeOf(this);
     }
 }

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/MainActivity.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/MainActivity.java
@@ -7,12 +7,12 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 
-import solutions.alterego.androidbound.ViewBinder;
 import solutions.alterego.androidbound.ViewModel;
 import solutions.alterego.androidbound.example.imageloader.UILImageLoader;
 import solutions.alterego.androidbound.example.util.AdvancedAndroidLoggerAdapter;
 import solutions.alterego.androidbound.example.viewmodels.MainActivityViewModel;
 import solutions.alterego.androidbound.interfaces.ILogger;
+import solutions.alterego.androidbound.interfaces.IViewBinder;
 
 
 public class MainActivity extends AppCompatActivity {
@@ -21,15 +21,14 @@ public class MainActivity extends AppCompatActivity {
 
     private static final IAndroidLogger.LoggingLevel LOGGING_LEVEL = IAndroidLogger.LoggingLevel.VERBOSE;
 
-    private ViewBinder mViewBinder;
-
     private ViewModel mViewModel;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ILogger logger = new AdvancedAndroidLoggerAdapter(LOGGING_TAG, LOGGING_LEVEL);
-        mViewBinder = new ViewBinder(this, logger);
+
+        IViewBinder mViewBinder = ExampleApplication.getViewBinder();
 
         mViewBinder.getFontManager().setDefaultFont(Typeface.createFromAsset(getAssets(), "Roboto-Bold.ttf"));
         mViewBinder.getFontManager().registerFont("light", Typeface.createFromAsset(getAssets(), "Roboto-Light.ttf"));
@@ -68,11 +67,5 @@ public class MainActivity extends AppCompatActivity {
     protected void onDestroy() {
         super.onDestroy();
         mViewModel.dispose();
-
-        //you shouldn't actually dispose of the view binder, it should be global (injected via Dagger maybe)!
-        //this is just for demonstration purposes
-        if (mViewBinder != null) {
-            mViewBinder.dispose();
-        }
     }
 }

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/MainBindingActivity.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/MainBindingActivity.java
@@ -2,14 +2,10 @@ package solutions.alterego.androidbound.example;
 
 import com.alterego.advancedandroidlogger.interfaces.IAndroidLogger;
 
-import android.graphics.Typeface;
 import android.os.Bundle;
 
-import solutions.alterego.androidbound.ViewBinder;
 import solutions.alterego.androidbound.android.BindingAppCompatActivity;
-import solutions.alterego.androidbound.example.imageloader.UILImageLoader;
 import solutions.alterego.androidbound.example.util.AdvancedAndroidLoggerAdapter;
-import solutions.alterego.androidbound.example.util.CustomValueConverters;
 import solutions.alterego.androidbound.example.viewmodels.MainBindingActivityViewModel;
 import solutions.alterego.androidbound.interfaces.ILogger;
 import solutions.alterego.androidbound.interfaces.IViewBinder;
@@ -20,24 +16,11 @@ public class MainBindingActivity extends BindingAppCompatActivity {
 
     private static final IAndroidLogger.LoggingLevel LOGGING_LEVEL = IAndroidLogger.LoggingLevel.VERBOSE;
 
-    private IViewBinder mViewBinder;
-
-    private CustomValueConverters mCustomValueConverters;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ILogger logger = new AdvancedAndroidLoggerAdapter(LOGGING_TAG, LOGGING_LEVEL);
-
-        ViewBinder viewBinder = new ViewBinder(this, logger);
-        viewBinder.getFontManager().setDefaultFont(Typeface.createFromAsset(getAssets(), "Roboto-Regular.ttf"));
-        viewBinder.getFontManager().registerFont("light", Typeface.createFromAsset(getAssets(), "Roboto-Light.ttf"));
-        viewBinder.getFontManager().registerFont("italic", Typeface.createFromAsset(getAssets(), "Roboto-Italic.ttf"));
-        viewBinder.getFontManager().registerFont("bold", Typeface.createFromAsset(getAssets(), "Roboto-Bold.ttf"));
-        mCustomValueConverters = new CustomValueConverters(this, viewBinder);
-        viewBinder.setImageLoader(new UILImageLoader(this, null));
-
-        setViewBinder(viewBinder);
+        setLogger(logger);
 
         setContentView(R.layout.activity_bindable_main, new MainBindingActivityViewModel(this, logger));
 
@@ -46,20 +29,11 @@ public class MainBindingActivity extends BindingAppCompatActivity {
 
     @Override
     public IViewBinder getViewBinder() {
-        return mViewBinder;
+        return ExampleApplication.getViewBinder();
     }
 
     @Override
     public void setViewBinder(IViewBinder viewBinder) {
-        mViewBinder = viewBinder;
     }
 
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        mCustomValueConverters = null;
-        if (getViewBinder() != null) {
-            getViewBinder().dispose();
-        }
-    }
 }

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/PaginatedRecyclerViewActivity.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/PaginatedRecyclerViewActivity.java
@@ -8,10 +8,8 @@ import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.OrientationHelper;
 
-import solutions.alterego.androidbound.ViewBinder;
 import solutions.alterego.androidbound.android.BindingAppCompatActivity;
 import solutions.alterego.androidbound.android.ui.BindableRecyclerView;
-import solutions.alterego.androidbound.example.imageloader.UILImageLoader;
 import solutions.alterego.androidbound.example.util.AdvancedAndroidLoggerAdapter;
 import solutions.alterego.androidbound.example.viewmodels.PaginatedViewModel;
 import solutions.alterego.androidbound.interfaces.ILogger;
@@ -21,8 +19,6 @@ public class PaginatedRecyclerViewActivity extends BindingAppCompatActivity {
 
     private static final IAndroidLogger.LoggingLevel LOGGING_LEVEL = IAndroidLogger.LoggingLevel.VERBOSE;
 
-    private IViewBinder mViewBinder;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -30,9 +26,7 @@ public class PaginatedRecyclerViewActivity extends BindingAppCompatActivity {
         ILogger logger = new AdvancedAndroidLoggerAdapter(PaginatedRecyclerViewActivity.class.getSimpleName(), LOGGING_LEVEL);
         TinyDancer.create().show(this);
 
-        ViewBinder viewBinder = new ViewBinder(this, logger);
-        viewBinder.setImageLoader(new UILImageLoader(this, null));
-        setViewBinder(viewBinder);
+        setLogger(logger);
 
         setContentView(R.layout.activity_paginated_recyclerview, new PaginatedViewModel(this, logger));
 
@@ -49,11 +43,10 @@ public class PaginatedRecyclerViewActivity extends BindingAppCompatActivity {
 
     @Override
     public IViewBinder getViewBinder() {
-        return mViewBinder;
+        return ExampleApplication.getViewBinder();
     }
 
     @Override
     public void setViewBinder(IViewBinder viewBinder) {
-        mViewBinder = viewBinder;
     }
 }

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/RecyclerViewActivity.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/RecyclerViewActivity.java
@@ -8,9 +8,7 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.OrientationHelper;
 import android.support.v7.widget.RecyclerView;
 
-import solutions.alterego.androidbound.ViewBinder;
 import solutions.alterego.androidbound.android.BindingAppCompatActivity;
-import solutions.alterego.androidbound.example.imageloader.UILImageLoader;
 import solutions.alterego.androidbound.example.util.AdvancedAndroidLoggerAdapter;
 import solutions.alterego.androidbound.example.viewmodels.RecyclerViewActivityViewModel;
 import solutions.alterego.androidbound.interfaces.ILogger;
@@ -22,17 +20,13 @@ public class RecyclerViewActivity extends BindingAppCompatActivity {
 
     private static final IAndroidLogger.LoggingLevel LOGGING_LEVEL = IAndroidLogger.LoggingLevel.VERBOSE;
 
-    private IViewBinder mViewBinder;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ILogger logger = new AdvancedAndroidLoggerAdapter(LOGGING_TAG, LOGGING_LEVEL);
         TinyDancer.create().show(this);
 
-        ViewBinder viewBinder = new ViewBinder(this, logger);
-        viewBinder.setImageLoader(new UILImageLoader(this, null));
-        setViewBinder(viewBinder);
+        setLogger(logger);
 
         setContentView(R.layout.activity_recyclerview, new RecyclerViewActivityViewModel(this, logger));
 
@@ -46,19 +40,10 @@ public class RecyclerViewActivity extends BindingAppCompatActivity {
 
     @Override
     public IViewBinder getViewBinder() {
-        return mViewBinder;
+        return ExampleApplication.getViewBinder();
     }
 
     @Override
     public void setViewBinder(IViewBinder viewBinder) {
-        mViewBinder = viewBinder;
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        if (getViewBinder() != null) {
-            getViewBinder().dispose();
-        }
     }
 }

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/RecyclerViewWithObjectsActivity.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/RecyclerViewWithObjectsActivity.java
@@ -5,9 +5,7 @@ import com.codemonkeylabs.fpslibrary.TinyDancer;
 
 import android.os.Bundle;
 
-import solutions.alterego.androidbound.ViewBinder;
 import solutions.alterego.androidbound.android.BindingAppCompatActivity;
-import solutions.alterego.androidbound.example.imageloader.UILImageLoader;
 import solutions.alterego.androidbound.example.util.AdvancedAndroidLoggerAdapter;
 import solutions.alterego.androidbound.example.viewmodels.RecyclerViewWithObjectsActivityViewModel;
 import solutions.alterego.androidbound.interfaces.ILogger;
@@ -19,36 +17,23 @@ public class RecyclerViewWithObjectsActivity extends BindingAppCompatActivity {
 
     private static final IAndroidLogger.LoggingLevel LOGGING_LEVEL = IAndroidLogger.LoggingLevel.VERBOSE;
 
-    private IViewBinder mViewBinder;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ILogger logger = new AdvancedAndroidLoggerAdapter(LOGGING_TAG, LOGGING_LEVEL);
         TinyDancer.create().show(this);
 
-        ViewBinder viewBinder = new ViewBinder(this, logger);
-        viewBinder.setImageLoader(new UILImageLoader(this, null));
-        setViewBinder(viewBinder);
+        setLogger(logger);
 
         setContentView(R.layout.activity_recyclerview_with_objects, new RecyclerViewWithObjectsActivityViewModel(this, logger));
     }
 
     @Override
     public IViewBinder getViewBinder() {
-        return mViewBinder;
+        return ExampleApplication.getViewBinder();
     }
 
     @Override
     public void setViewBinder(IViewBinder viewBinder) {
-        mViewBinder = viewBinder;
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        if (getViewBinder() != null) {
-            getViewBinder().dispose();
-        }
     }
 }


### PR DESCRIPTION
@bblackbelt this should definitely resolve the problem with memory leaks. The problem was that delegates were calling `clearBindingForViewAndChildren(getBoundActivity().getWindow().getDecorView().getRootView())`, and the `ViewBinder` was checking if the passed view was a `ViewGroup` instance. It turns out that the DecorView passed as the root of the Window *wasn't* a `ViewGroup`, at least not on Android 6. That implementation uses internal `PhoneWindow.DecorView` class that has children but is totally closed off.

For that purpose, I added an explicit `IViewBinder.disposeOf(Context)` method that should be called from `Activity.onDestroy()` which then manually checks every bound view and it's `Context` and removes it if necessary.

I tested it on the example and it works. I also added a debug mode to the `IViewBinder` that will print more details and how many views are remaining with the same context. It slows down considerably so it's outside of normal logging.

If everything looks ok, gonna make a new release after this is merged.