### PR TITLE
ViewModel doesn't implement INeedsLogger any more

### DIFF
--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewModel.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewModel.java
@@ -6,24 +6,14 @@ import lombok.Getter;
 import lombok.experimental.Accessors;
 import solutions.alterego.androidbound.binding.interfaces.INotifyPropertyChanged;
 import solutions.alterego.androidbound.interfaces.IDisposable;
-import solutions.alterego.androidbound.interfaces.ILogger;
-import solutions.alterego.androidbound.interfaces.INeedsLogger;
 
 @Accessors(prefix = "m")
-public class ViewModel implements INeedsLogger, INotifyPropertyChanged, IDisposable {
-
-    @Getter
-    protected transient ILogger mLogger = NullLogger.instance;
+public class ViewModel implements INotifyPropertyChanged, IDisposable {
 
     private transient PublishSubject<String> propertyChanges = PublishSubject.create();
 
     @Getter
     protected boolean mDisposed = false;
-
-    @Override
-    public void setLogger(ILogger logger) {
-        mLogger = logger.getLogger(this);
-    }
 
     @Override
     public Observable<String> onPropertyChanged() {
@@ -46,11 +36,7 @@ public class ViewModel implements INeedsLogger, INotifyPropertyChanged, IDisposa
     }
 
     protected void raisePropertyChanged(String property) {
-        try {
-            propertyChanges.onNext(property);
-        } catch (Exception e) {
-            mLogger.error("exception when raising property changes = " + e.getMessage());
-        }
+        propertyChanges.onNext(property);
     }
 
 }

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/android/BoundActivityDelegate.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/android/BoundActivityDelegate.java
@@ -40,7 +40,7 @@ public class BoundActivityDelegate
     @Getter
     protected Map<String, ViewModel> mViewModels;
 
-    private ILogger mLogger = null;
+    private transient ILogger mLogger = NullLogger.instance;
 
     private transient WeakReference<Activity> mBoundActivity;
 
@@ -110,7 +110,10 @@ public class BoundActivityDelegate
             ((INeedsFragmentManager) viewModel).setFragmentManager(getBoundActivity().getFragmentManager());
         }
 
-        viewModel.setLogger(getLogger());
+        if (viewModel instanceof INeedsLogger) {
+            ((INeedsLogger) viewModel).setLogger(mLogger);
+        }
+
         mViewModels.put(id, viewModel);
 
         View view = getViewBinder().inflate(getBoundActivity(), viewModel, layoutResID, null);
@@ -293,7 +296,9 @@ public class BoundActivityDelegate
 
         if (getViewModels() != null) {
             for (ViewModel viewModel : getViewModels().values()) {
-                viewModel.setLogger(getLogger());
+                if (viewModel instanceof INeedsLogger) {
+                    ((INeedsLogger) viewModel).setLogger(getLogger());
+                }
             }
         }
     }

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/android/BoundFragmentDelegate.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/android/BoundFragmentDelegate.java
@@ -45,7 +45,7 @@ public class BoundFragmentDelegate
     @Getter
     private Map<String, ViewModel> mViewModels;
 
-    private ILogger mLogger = NullLogger.instance;
+    private transient ILogger mLogger = NullLogger.instance;
 
     private transient View mBoundView;
 
@@ -106,7 +106,10 @@ public class BoundFragmentDelegate
             ((INeedsFragmentManager) viewModel).setFragmentManager(getBoundActivity().getFragmentManager());
         }
 
-        viewModel.setLogger(getLogger());
+        if (viewModel instanceof INeedsLogger) {
+            ((INeedsLogger) viewModel).setLogger(mLogger);
+        }
+
         mViewModels.put(id, viewModel);
 
         View view = getViewBinder().inflate(getBoundActivity(), viewModel, layoutResID, parent, false);
@@ -305,7 +308,9 @@ public class BoundFragmentDelegate
 
         if (getViewModels() != null) {
             for (ViewModel viewModel : getViewModels().values()) {
-                viewModel.setLogger(getLogger());
+                if (viewModel instanceof INeedsLogger) {
+                    ((INeedsLogger) viewModel).setLogger(getLogger());
+                }
             }
         }
     }

--- a/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/ListItemDetailActivityViewModel.java
+++ b/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/ListItemDetailActivityViewModel.java
@@ -14,7 +14,6 @@ public class ListItemDetailActivityViewModel extends AndroidViewModel {
     private String mTitle;
 
     public ListItemDetailActivityViewModel(Activity activity, ILogger logger, String title, String imageUrl) {
-        setLogger(logger);
         setParentActivity(activity);
 
         setTitle(title);

--- a/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/ListViewActivityViewModel.java
+++ b/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/ListViewActivityViewModel.java
@@ -24,7 +24,6 @@ public class ListViewActivityViewModel extends AndroidViewModel {
     private List<ListViewItem> mExampleList = new ArrayList<ListViewItem>();
 
     public ListViewActivityViewModel(Activity activity, ILogger logger) {
-        setLogger(logger);
         setParentActivity(activity);
 
         setListViewActivityTitle("ListView activity");

--- a/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/ListViewWithObjectsActivityViewModel.java
+++ b/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/ListViewWithObjectsActivityViewModel.java
@@ -28,7 +28,6 @@ public class ListViewWithObjectsActivityViewModel extends AndroidViewModel {
     private List<Object> mExampleList = new ArrayList<Object>();
 
     public ListViewWithObjectsActivityViewModel(Activity activity, ILogger logger) {
-        setLogger(logger);
         setParentActivity(activity);
 
         setListViewActivityTitle("ListView with objects activity");

--- a/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/MainActivityViewModel.java
+++ b/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/MainActivityViewModel.java
@@ -22,7 +22,6 @@ public class MainActivityViewModel extends AndroidViewModel {
     private String mOpenBindableActivityText;
 
     public MainActivityViewModel(Activity activity, ILogger logger) {
-        setLogger(logger);
         setParentActivity(activity);
 
         setMainActivityTitle("Main Activity");

--- a/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/MainBindingActivityViewModel.java
+++ b/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/MainBindingActivityViewModel.java
@@ -13,12 +13,14 @@ import android.text.Spanned;
 import android.text.style.UnderlineSpan;
 import android.widget.Toast;
 
+import solutions.alterego.androidbound.NullLogger;
 import solutions.alterego.androidbound.android.AndroidViewModel;
 import solutions.alterego.androidbound.example.support.MainActivity;
 import solutions.alterego.androidbound.example.support.R;
 import solutions.alterego.androidbound.interfaces.ILogger;
+import solutions.alterego.androidbound.interfaces.INeedsLogger;
 
-public class MainBindingActivityViewModel extends AndroidViewModel {
+public class MainBindingActivityViewModel extends AndroidViewModel implements INeedsLogger {
 
     private Spannable mMainActivityTitle;
 
@@ -31,6 +33,8 @@ public class MainBindingActivityViewModel extends AndroidViewModel {
     private SpannableString mTextViewBoundToEditText = new SpannableString("empty");
 
     private String mBoundEditTextText = mEditTextText;
+
+    private ILogger mLogger = NullLogger.instance;
 
     public MainBindingActivityViewModel(Activity activity, ILogger logger) {
         setLogger(logger);
@@ -185,5 +189,10 @@ public class MainBindingActivityViewModel extends AndroidViewModel {
 
     public void setBoundEditTextText(String mBoundEditTextText) {
         this.mBoundEditTextText = mBoundEditTextText;
+    }
+
+    @Override
+    public void setLogger(ILogger logger) {
+        mLogger = logger;
     }
 }

--- a/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/PaginatedViewModel.java
+++ b/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/PaginatedViewModel.java
@@ -129,7 +129,6 @@ public class PaginatedViewModel extends ViewModel {
     });
 
     public PaginatedViewModel(Activity activity, ILogger logger) {
-        setLogger(logger);
         mLoadNextPage = new PageDescriptor.PageDescriptorBuilder()
                 .setPageSize(20)
                 .setStartPage(1)

--- a/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/RecyclerViewActivityViewModel.java
+++ b/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/RecyclerViewActivityViewModel.java
@@ -25,7 +25,6 @@ public class RecyclerViewActivityViewModel extends AndroidViewModel {
     private List<Object> mExampleListLinear = new ArrayList<Object>();
 
     public RecyclerViewActivityViewModel(Activity activity, ILogger logger) {
-        setLogger(logger);
         setParentActivity(activity);
 
         setListViewActivityTitle("RecyclerView with objects activity");

--- a/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/RecyclerViewWithObjectsActivityViewModel.java
+++ b/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/RecyclerViewWithObjectsActivityViewModel.java
@@ -29,7 +29,6 @@ public class RecyclerViewWithObjectsActivityViewModel extends AndroidViewModel {
     private List<Object> mExampleListStaggered = new ArrayList<Object>();
 
     public RecyclerViewWithObjectsActivityViewModel(Activity activity, ILogger logger) {
-        setLogger(logger);
         setParentActivity(activity);
 
         setListViewActivityTitle("RecyclerView with objects activity");

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/viewmodels/ListItemDetailActivityViewModel.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/viewmodels/ListItemDetailActivityViewModel.java
@@ -19,7 +19,6 @@ public class ListItemDetailActivityViewModel extends AndroidViewModel {
     private String mTitle;
 
     public ListItemDetailActivityViewModel(Activity activity, ILogger logger, String title, String imageUrl) {
-        setLogger(logger);
         setParentActivity(activity);
 
         setTitle(title);

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/viewmodels/ListViewActivityViewModel.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/viewmodels/ListViewActivityViewModel.java
@@ -30,7 +30,6 @@ public class ListViewActivityViewModel extends AndroidViewModel {
     private List<ListViewItem> mExampleList = new ArrayList<ListViewItem>();
 
     public ListViewActivityViewModel(Activity activity, ILogger logger) {
-        setLogger(logger);
         setParentActivity(activity);
 
         setListViewActivityTitle("ListView activity");

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/viewmodels/ListViewWithObjectsActivityViewModel.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/viewmodels/ListViewWithObjectsActivityViewModel.java
@@ -34,7 +34,6 @@ public class ListViewWithObjectsActivityViewModel extends AndroidViewModel {
     private List<Object> mExampleList = new ArrayList<Object>();
 
     public ListViewWithObjectsActivityViewModel(Activity activity, ILogger logger) {
-        setLogger(logger);
         setParentActivity(activity);
 
         setListViewActivityTitle("ListView with objects activity");

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/viewmodels/MainActivityViewModel.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/viewmodels/MainActivityViewModel.java
@@ -27,7 +27,6 @@ public class MainActivityViewModel extends AndroidViewModel {
     private String mOpenBindableActivityText;
 
     public MainActivityViewModel(Activity activity, ILogger logger) {
-        setLogger(logger);
         setParentActivity(activity);
 
         setMainActivityTitle("Main Activity");

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/viewmodels/MainBindingActivityViewModel.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/viewmodels/MainBindingActivityViewModel.java
@@ -16,13 +16,15 @@ import android.widget.Toast;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import solutions.alterego.androidbound.NullLogger;
 import solutions.alterego.androidbound.android.AndroidViewModel;
 import solutions.alterego.androidbound.example.MainActivity;
 import solutions.alterego.androidbound.example.R;
 import solutions.alterego.androidbound.interfaces.ILogger;
+import solutions.alterego.androidbound.interfaces.INeedsLogger;
 
 @Accessors(prefix = "m")
-public class MainBindingActivityViewModel extends AndroidViewModel {
+public class MainBindingActivityViewModel extends AndroidViewModel implements INeedsLogger {
 
     @Getter
     private Spannable mMainActivityTitle;
@@ -42,6 +44,8 @@ public class MainBindingActivityViewModel extends AndroidViewModel {
     @Getter
     @Setter
     private String mBoundEditTextText = mEditTextText;
+
+    private ILogger mLogger = NullLogger.instance;
 
     public MainBindingActivityViewModel(Activity activity, ILogger logger) {
         setLogger(logger);
@@ -168,5 +172,10 @@ public class MainBindingActivityViewModel extends AndroidViewModel {
 
     public void doTextViewLongClick() {
         Toast.makeText(getParentActivity(), "long clicked text view!", Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void setLogger(ILogger logger) {
+        mLogger = logger;
     }
 }

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/viewmodels/PaginatedViewModel.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/viewmodels/PaginatedViewModel.java
@@ -60,7 +60,6 @@ public class PaginatedViewModel extends ViewModel {
     });
 
     public PaginatedViewModel(Activity activity, ILogger logger) {
-        setLogger(logger);
         mLoadNextPage = new PageDescriptor.PageDescriptorBuilder()
                 .setPageSize(20)
                 .setStartPage(1)

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/viewmodels/RecyclerViewActivityViewModel.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/viewmodels/RecyclerViewActivityViewModel.java
@@ -31,7 +31,6 @@ public class RecyclerViewActivityViewModel extends AndroidViewModel {
     private List<Object> mExampleListLinear = new ArrayList<Object>();
 
     public RecyclerViewActivityViewModel(Activity activity, ILogger logger) {
-        setLogger(logger);
         setParentActivity(activity);
 
         setListViewActivityTitle("RecyclerView with objects activity");

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/viewmodels/RecyclerViewWithObjectsActivityViewModel.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/viewmodels/RecyclerViewWithObjectsActivityViewModel.java
@@ -35,7 +35,6 @@ public class RecyclerViewWithObjectsActivityViewModel extends AndroidViewModel {
     private List<Object> mExampleListStaggered = new ArrayList<Object>();
 
     public RecyclerViewWithObjectsActivityViewModel(Activity activity, ILogger logger) {
-        setLogger(logger);
         setParentActivity(activity);
 
         setListViewActivityTitle("RecyclerView with objects activity");

--- a/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/BoundSupportActivityDelegate.java
+++ b/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/BoundSupportActivityDelegate.java
@@ -10,6 +10,7 @@ import lombok.experimental.Accessors;
 import solutions.alterego.androidbound.ViewModel;
 import solutions.alterego.androidbound.android.BoundActivityDelegate;
 import solutions.alterego.androidbound.android.interfaces.INeedsActivity;
+import solutions.alterego.androidbound.interfaces.INeedsLogger;
 import solutions.alterego.androidbound.interfaces.IViewBinder;
 import solutions.alterego.androidbound.support.android.interfaces.INeedsSupportFragmentManager;
 
@@ -50,7 +51,10 @@ public class BoundSupportActivityDelegate extends BoundActivityDelegate {
             ((INeedsSupportFragmentManager) viewModel).setFragmentManager(((FragmentActivity) getBoundActivity()).getSupportFragmentManager());
         }
 
-        viewModel.setLogger(getLogger());
+        if (viewModel instanceof INeedsLogger) {
+            ((INeedsLogger) viewModel).setLogger(getLogger());
+        }
+
         mViewModels.put(id, viewModel);
 
         View view = getViewBinder().inflate(getBoundActivity(), viewModel, layoutResID, null);

--- a/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/BoundSupportFragmentDelegate.java
+++ b/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/BoundSupportFragmentDelegate.java
@@ -108,7 +108,10 @@ public class BoundSupportFragmentDelegate
             ((INeedsSupportFragmentManager) viewModel).setFragmentManager(((FragmentActivity) getBoundActivity()).getSupportFragmentManager());
         }
 
-        viewModel.setLogger(getLogger());
+        if (viewModel instanceof INeedsLogger) {
+            ((INeedsLogger) viewModel).setLogger(getLogger());
+        }
+
         mViewModels.put(id, viewModel);
 
         View view = getViewBinder().inflate(getBoundActivity(), viewModel, layoutResID, parent, false);
@@ -296,7 +299,9 @@ public class BoundSupportFragmentDelegate
 
         if (getViewModels() != null) {
             for (ViewModel viewModel : getViewModels().values()) {
-                viewModel.setLogger(getLogger());
+                if (viewModel instanceof INeedsLogger) {
+                    ((INeedsLogger) viewModel).setLogger(getLogger());
+                }
             }
         }
     }


### PR DESCRIPTION
all `ViewModels` previously implemented `INeedsLogger` - but if you want to use a different logger interface, then you would have two different loggers in the `ViewModel`. This has now been removed. If you want to have the viewbinding logger in the `ViewModel`, you can implement the interface manually, and it will be automatically injected during viewbinding.