### PR TITLE
Improvement/use debug mode to rethrow exceptions

### DIFF
--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewBinder.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewBinder.java
@@ -57,10 +57,15 @@ public class ViewBinder implements IViewBinder {
     private Field mLayoutInflaterFactory2Field = null;
 
     public ViewBinder(Context ctx) {
-        this(ctx, NullLogger.instance);
+        this(ctx, NullLogger.instance, false);
     }
 
     public ViewBinder(Context ctx, ILogger logger) {
+        this(ctx, logger, false);
+    }
+
+    public ViewBinder(Context ctx, ILogger logger, boolean debugMode) {
+        mDebugMode = debugMode;
         setLogger(logger);
         setContext(ctx);
         init();
@@ -77,13 +82,7 @@ public class ViewBinder implements IViewBinder {
     }
 
     protected IViewBindingEngine createViewBindingEngine(ILogger logger) {
-        return new ViewBindingEngine(logger);
-    }
-
-    @Override
-    public void setDebugMode(boolean debugMode) {
-        mDebugMode = debugMode;
-        mViewBindingEngine.setDebugMode(debugMode);
+        return new ViewBindingEngine(logger, mDebugMode);
     }
 
     @Override

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewBinder.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewBinder.java
@@ -74,7 +74,7 @@ public class ViewBinder implements IViewBinder {
     private void init() {
         mViewBindingEngine = createViewBindingEngine(getLogger());
 
-        mViewResolver = new ChainedViewResolver(new ViewResolver(getLogger()));
+        mViewResolver = new ChainedViewResolver(new ViewResolver(getLogger(), mDebugMode));
         mInflaterFactory = new BindableLayoutInflaterFactory(this, mViewResolver);
         setFontManager(new FontManager());
 

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewBinder.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/ViewBinder.java
@@ -219,6 +219,9 @@ public class ViewBinder implements IViewBinder {
             } catch (NoSuchFieldException e) {
                 mLogger.error("forceSetFactory2 Could not find field 'mFactory2' on class " + LayoutInflater.class.getName()
                         + "; inflation may have unexpected results." + e.getMessage());
+                if (isDebugMode()) {
+                    throw new RuntimeException(e);
+                }
             }
             mCheckedField = true;
         }
@@ -229,6 +232,9 @@ public class ViewBinder implements IViewBinder {
                 mLogger.error(
                         "forceSetFactory2 could not set the Factory2 on LayoutInflater " + inflater + "; inflation may have unexpected results." + e
                                 .getMessage());
+                if (isDebugMode()) {
+                    throw new RuntimeException(e);
+                }
             }
         }
     }

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/android/BoundActivityDelegate.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/android/BoundActivityDelegate.java
@@ -72,7 +72,10 @@ public class BoundActivityDelegate
     @Override
     public void setContentView(int layoutResID, ViewModel viewModel) {
         if (mBoundActivity == null || getBoundActivity() == null) {
-            throw new RuntimeException("Bound Activity is null!");
+            throw new RuntimeException("Bound Activity is null! ViewModel = " + viewModel);
+        }
+        if (viewModel == null) {
+            throw new RuntimeException("Bound ViewModel is null! Activity = " + getBoundActivity());
         }
 
         getBoundActivity().setContentView(addViewModel(layoutResID, viewModel, TAG_VIEWMODEL_MAIN));

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/android/BoundActivityDelegate.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/android/BoundActivityDelegate.java
@@ -81,11 +81,11 @@ public class BoundActivityDelegate
     @Override
     public View addViewModel(int layoutResID, ViewModel viewModel, String id) {
         if (getBoundActivity() == null) {
-            throw new RuntimeException("Bound Activity is null!");
+            throw new RuntimeException("Bound Activity is null! ViewModel = " + viewModel);
         }
 
         if (viewModel == null) {
-            throw new RuntimeException("viewModel is null!");
+            throw new RuntimeException("ViewModel is null! Activity = " + getBoundActivity());
         }
 
         if (mViewModels == null) {
@@ -93,7 +93,7 @@ public class BoundActivityDelegate
         }
 
         if (mViewModels.values().contains(viewModel)) {
-            throw new RuntimeException("cannot add same instance of viewModel twice!");
+            throw new RuntimeException("cannot add same instance of viewModel twice! ViewModel = " + viewModel);
         }
 
         if (viewModel instanceof INeedsActivity) {

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/android/BoundFragmentDelegate.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/android/BoundFragmentDelegate.java
@@ -79,11 +79,11 @@ public class BoundFragmentDelegate
     @Override
     public View addViewModel(int layoutResID, ViewModel viewModel, String id, @Nullable ViewGroup parent) {
         if (getBoundActivity() == null) {
-            throw new RuntimeException("Bound Activity is null!");
+            throw new RuntimeException("Bound Activity is null! ViewModel = " + viewModel);
         }
 
         if (viewModel == null) {
-            throw new RuntimeException("viewModel is null!");
+            throw new RuntimeException("ViewModel is null! Activity = " + getBoundActivity());
         }
 
         if (mViewModels == null) {

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/android/adapters/BindableListAdapter.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/android/adapters/BindableListAdapter.java
@@ -86,8 +86,12 @@ public class BindableListAdapter extends BaseAdapter {
         convertView = checkInflatedView(convertView, position, parent);
 
         if (convertView == null) {
-            mLogger.warning("BindableListAdapter getView is null, returning ViewStub!");
+            String msg = "BindableListAdapter getView is null, returning ViewStub!";
+            mLogger.warning(msg);
             convertView = new ViewStub(context);
+            if (viewBinder.isDebugMode()) {
+                throw new RuntimeException(msg);
+            }
         }
         return convertView;
     }

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/android/viewresolvers/ViewResolver.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/android/viewresolvers/ViewResolver.java
@@ -61,9 +61,12 @@ public class ViewResolver implements IViewResolver {
         }
     };
 
+    private final boolean mDebugMode;
+
     protected ILogger logger;
 
-    public ViewResolver(ILogger logger) {
+    public ViewResolver(ILogger logger, boolean debugMode) {
+        mDebugMode = debugMode;
         setLogger(logger);
     }
 
@@ -94,6 +97,9 @@ public class ViewResolver implements IViewResolver {
             throw new Exception("constructor not found");
         } catch (Exception e) {
             logger.warning("failed creating instance of class " + resolvedClass + ", exception: " + e);
+            if (mDebugMode) {
+                throw new RuntimeException(e);
+            }
         }
 
         return null;
@@ -118,6 +124,9 @@ public class ViewResolver implements IViewResolver {
             logger.debug("Resolving " + name + " with " + result);
             return Class.forName(result);
         } catch (ClassNotFoundException e) {
+            if (mDebugMode) {
+                throw new RuntimeException(e);
+            }
             return null;
         }
     }

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/android/viewresolvers/ViewResolver.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/android/viewresolvers/ViewResolver.java
@@ -65,6 +65,8 @@ public class ViewResolver implements IViewResolver {
 
     protected ILogger logger;
 
+    protected String mLoggingTag = getClass().getSimpleName();
+
     public ViewResolver(ILogger logger, boolean debugMode) {
         mDebugMode = debugMode;
         setLogger(logger);
@@ -74,7 +76,7 @@ public class ViewResolver implements IViewResolver {
     public View createView(String name, Context context, AttributeSet attrs) {
         Class<?> resolvedClass = resolveName(name);
         if (resolvedClass == null) {
-            logger.debug(getClass().getSimpleName() + " couldn't find view = " + name);
+            logger.debug(mLoggingTag + " couldn't find view = " + name);
             return null;
         }
         try {
@@ -117,12 +119,12 @@ public class ViewResolver implements IViewResolver {
         }
 
         if (mappings.containsKey(result)) {
-            logger.debug(getClass().getSimpleName() + " mapping " + name + " to " + mappings.get(result));
+            logger.debug(mLoggingTag + " mapping " + name + " to " + mappings.get(result));
             return mappings.get(result);
         }
 
         try {
-            logger.debug(getClass().getSimpleName() + " resolving " + name + " with " + result);
+            logger.debug(mLoggingTag + " resolving " + name + " with " + result);
             return Class.forName(result);
         } catch (ClassNotFoundException e) {
             if (mDebugMode) {

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/android/viewresolvers/ViewResolver.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/android/viewresolvers/ViewResolver.java
@@ -74,7 +74,7 @@ public class ViewResolver implements IViewResolver {
     public View createView(String name, Context context, AttributeSet attrs) {
         Class<?> resolvedClass = resolveName(name);
         if (resolvedClass == null) {
-            logger.warning("View not found for name " + name);
+            logger.debug(getClass().getSimpleName() + " couldn't find view = " + name);
             return null;
         }
         try {
@@ -117,11 +117,12 @@ public class ViewResolver implements IViewResolver {
         }
 
         if (mappings.containsKey(result)) {
+            logger.debug(getClass().getSimpleName() + " mapping " + name + " to " + mappings.get(result));
             return mappings.get(result);
         }
 
         try {
-            logger.debug("Resolving " + name + " with " + result);
+            logger.debug(getClass().getSimpleName() + " resolving " + name + " with " + result);
             return Class.forName(result);
         } catch (ClassNotFoundException e) {
             if (mDebugMode) {

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/BindingAssociationEngine.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/BindingAssociationEngine.java
@@ -1,5 +1,7 @@
 package solutions.alterego.androidbound.binding;
 
+import android.annotation.SuppressLint;
+
 import java.util.Locale;
 
 import io.reactivex.disposables.Disposable;
@@ -109,6 +111,7 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
         }
     }
 
+    @SuppressLint("RxSubscribeOnError")
     private void createSourceBinding(Object source) {
         boolean needsSubs = needsSourceDisposable();
 
@@ -131,6 +134,7 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
         }
     }
 
+    @SuppressLint("RxSubscribeOnError")
     private void createRemoveBinding(Object target) {
         boolean needsSubs = needsTargetRemove();
         mTargetBinding = mTargetFactory.create(target, mBindingSpecification.getTarget(), needsSubs);
@@ -150,6 +154,7 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
         }
     }
 
+    @SuppressLint("RxSubscribeOnError")
     private void createTargetBinding(Object target) {
         boolean needsSubs = needsTargetDisposable();
 
@@ -171,7 +176,7 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
         }
     }
 
-
+    @SuppressLint("RxSubscribeOnError")
     private void createAccumulateSourceBinding(Object source) {
         boolean needsSubs = needsTargetAccumulate();
 
@@ -193,6 +198,7 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
         }
     }
 
+    @SuppressLint("RxSubscribeOnError")
     private void createAccumulateTargetBinding(Object target) {
         boolean needsSubs = needsSourceAccumulate();
         mTargetBinding = mTargetFactory.create(target, mBindingSpecification.getTarget(), needsSubs);

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/BindingAssociationEngine.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/BindingAssociationEngine.java
@@ -47,7 +47,8 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
 
     private IBindingFactory mTargetFactory;
 
-    public BindingAssociationEngine(BindingRequest request, IBindingFactory sourceFactory, IBindingFactory targetFactory, ILogger logger, boolean debugMode) {
+    public BindingAssociationEngine(BindingRequest request, IBindingFactory sourceFactory, IBindingFactory targetFactory, ILogger logger,
+            boolean debugMode) {
         mMode = request.getSpecification().getMode();
         mSourceFactory = sourceFactory;
         mTargetFactory = targetFactory;
@@ -131,8 +132,11 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
                             }
                         });
             } else {
-                mLogger.warning("Binding " + mBindingSpecification.getSource()
-                        + " needs Disposable, but changes were not available");
+                String msg = "Binding " + mBindingSpecification.getSource() + " needs Disposable, but changes were not available = " + mBindingSpecification.toString();
+                mLogger.warning(msg);
+                if (mDebugMode) {
+                    throw new RuntimeException(msg);
+                }
             }
         }
     }
@@ -152,7 +156,11 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
                             }
                         });
             } else {
-                mLogger.warning("Binding " + mBindingSpecification.getTarget() + " needs Disposable, but changes were not available.");
+                String msg = "Binding " + mBindingSpecification.getTarget() + " needs Disposable, but changes were not available.";
+                mLogger.warning(msg);
+                if (mDebugMode) {
+                    throw new RuntimeException(msg);
+                }
             }
         }
     }
@@ -174,7 +182,11 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
                             }
                         });
             } else {
-                mLogger.warning("Binding " + mBindingSpecification.getTarget() + " needs Disposable, but changes were not available.");
+                String msg = "Binding " + mBindingSpecification.getTarget() + " needs Disposable, but changes were not available.";
+                mLogger.warning(msg);
+                if (mDebugMode) {
+                    throw new RuntimeException(msg);
+                }
             }
         }
     }
@@ -196,7 +208,11 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
                             }
                         });
             } else {
-                mLogger.warning("Binding " + mBindingSpecification.getSource() + " needs Disposable, but changes were not available");
+                String msg = "Binding " + mBindingSpecification.getSource() + " needs Disposable, but changes were not available";
+                mLogger.warning(msg);
+                if (mDebugMode) {
+                    throw new RuntimeException(msg);
+                }
             }
         }
     }
@@ -216,7 +232,11 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
                             }
                         });
             } else {
-                mLogger.warning("Binding " + mBindingSpecification.getTarget() + " needs Disposable, but changes were not available.");
+                String msg = "Binding " + mBindingSpecification.getTarget() + " needs Disposable, but changes were not available.";
+                mLogger.warning(msg);
+                if (mDebugMode) {
+                    throw new RuntimeException(msg);
+                }
             }
         }
     }
@@ -289,8 +309,12 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
                         "updating target type = " + mTargetBinding.getType() + " with unwrapped source = " + unwrap(source) + ", result = " + result
                                 + " using converter = " + converter);
             } else {
-                mLogger.warning("Switching to fallback value for " + mBindingSpecification.getSource());
                 result = mBindingSpecification.getFallbackValue();
+                String msg = "Switching to fallback value for " + mBindingSpecification.getSource() + ", fallback = " + result;
+                mLogger.warning(msg);
+                if (mDebugMode) {
+                    throw new RuntimeException(msg);
+                }
             }
 
             mTargetBinding.setValue(result);
@@ -343,8 +367,12 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
                         "removing, source type = " + mSourceBinding.getType() + " with unwrapped obj = " + unwrap(obj) + ", result = " + result
                                 + " using converter = " + converter);
             } else {
-                mLogger.warning("Switching to fallback value for " + mBindingSpecification.getSource());
                 result = mBindingSpecification.getFallbackValue();
+                String msg = "Switching to fallback value for " + mBindingSpecification.getSource() + ", fallback = " + result;
+                mLogger.warning(msg);
+                if (mDebugMode) {
+                    throw new RuntimeException(msg);
+                }
             }
             mTargetBinding.removeValue(result);
         } catch (Exception e) {
@@ -369,8 +397,12 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
                                 + " using converter = " + converter);
 
             } else {
-                mLogger.warning("Switching to fallback value for " + mBindingSpecification.getSource());
+                String msg = "Switching to fallback value for " + mBindingSpecification.getSource();
+                mLogger.warning(msg);
                 result = mBindingSpecification.getFallbackValue();
+                if (mDebugMode) {
+                    throw new RuntimeException(msg);
+                }
             }
             mTargetBinding.addValue(result);
         } catch (Exception e) {
@@ -391,8 +423,7 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
                             Locale.getDefault());
             mLogger.verbose(
                     "accumulating to source, source type = " + mSourceBinding.getType() + " with unwrapped obj = " + unwrap(obj) + ", result = "
-                            + result
-                            + " using converter = " + converter);
+                            + result + " using converter = " + converter);
 
             mSourceBinding.addValue(result);
         } catch (Exception e) {

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/BindingAssociationEngine.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/BindingAssociationEngine.java
@@ -27,6 +27,8 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
 
     private BindingSpecification mBindingSpecification;
 
+    private boolean mDebugMode;
+
     private IBinding mSourceBinding;
 
     private IBinding mTargetBinding;
@@ -45,11 +47,12 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
 
     private IBindingFactory mTargetFactory;
 
-    public BindingAssociationEngine(BindingRequest request, IBindingFactory sourceFactory, IBindingFactory targetFactory, ILogger logger) {
+    public BindingAssociationEngine(BindingRequest request, IBindingFactory sourceFactory, IBindingFactory targetFactory, ILogger logger, boolean debugMode) {
         mMode = request.getSpecification().getMode();
         mSourceFactory = sourceFactory;
         mTargetFactory = targetFactory;
         mBindingSpecification = request.getSpecification();
+        mDebugMode = debugMode;
 
         setLogger(logger);
         createTargetBinding(request.getTarget());
@@ -263,15 +266,15 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
         }
     }
 
-    public boolean needsTargetAccumulate() {
+    protected boolean needsTargetAccumulate() {
         return mMode == BindingMode.Accumulate || mMode == BindingMode.AccumulateTwoWay;
     }
 
-    private boolean needsTargetRemove() {
+    protected boolean needsTargetRemove() {
         return mMode == BindingMode.RemoveSource;
     }
 
-    public boolean needsSourceAccumulate() {
+    protected boolean needsSourceAccumulate() {
         return mMode == BindingMode.AccumulateToSource || mMode == BindingMode.AccumulateTwoWay;
     }
 
@@ -295,6 +298,9 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
             mLogger.error(
                     "Error occurred while binding " + mBindingSpecification.getSource() + " to target " + mBindingSpecification.getTarget() + ": " + e
                             .getMessage());
+            if (mDebugMode) {
+                throw new RuntimeException(e);
+            }
         }
     }
 
@@ -312,6 +318,9 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
             mLogger.error(
                     "Error occurred while binding " + mBindingSpecification.getTarget() + " to source " + mBindingSpecification.getSource() + ": " + e
                             .getMessage());
+            if (mDebugMode) {
+                throw new RuntimeException(e);
+            }
         }
     }
 
@@ -342,6 +351,9 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
             mLogger.error(
                     "Error occurred while binding " + mBindingSpecification.getSource() + " to target " + mBindingSpecification.getTarget() + ": " + e
                             .getMessage());
+            if (mDebugMode) {
+                throw new RuntimeException(e);
+            }
         }
     }
 
@@ -365,6 +377,9 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
             mLogger.error(
                     "Error occurred while binding " + mBindingSpecification.getSource() + " to target " + mBindingSpecification.getTarget() + ": " + e
                             .getMessage());
+            if (mDebugMode) {
+                throw new RuntimeException(e);
+            }
         }
     }
 
@@ -384,6 +399,9 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
             mLogger.error(
                     "Error occurred while binding " + mBindingSpecification.getTarget() + " to source " + mBindingSpecification.getSource() + ": " + e
                             .getMessage());
+            if (mDebugMode) {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/BindingAssociationEngine.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/BindingAssociationEngine.java
@@ -311,9 +311,11 @@ public class BindingAssociationEngine implements IBindingAssociationEngine {
             } else {
                 result = mBindingSpecification.getFallbackValue();
                 String msg = "Switching to fallback value for " + mBindingSpecification.getSource() + ", fallback = " + result;
-                mLogger.warning(msg);
+
                 if (mDebugMode) {
-                    throw new RuntimeException(msg);
+                    mLogger.error(msg);
+                } else {
+                    mLogger.warning(msg);
                 }
             }
 

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/NullViewBindingEngine.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/NullViewBindingEngine.java
@@ -22,11 +22,6 @@ public class NullViewBindingEngine implements IViewBindingEngine {
     }
 
     @Override
-    public void setDebugMode(boolean debugMode) {
-
-    }
-
-    @Override
     public ILogger getLogger() {
         return null;
     }

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/TextSpecificationBinder.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/TextSpecificationBinder.java
@@ -21,17 +21,21 @@ public class TextSpecificationBinder implements IBinder {
 
     private final IBindingFactory mTargetFactory;
 
+    private final boolean mDebugMode;
+
     private ILogger mLogger;
 
     public TextSpecificationBinder(
             IParser<List<BindingSpecification>> parser,
             IBindingFactory sourceFactory,
             IBindingFactory targetFactory,
-            ILogger logger) {
+            ILogger logger,
+            boolean debugMode) {
 
         mParser = parser;
         mSourceFactory = sourceFactory;
         mTargetFactory = targetFactory;
+        mDebugMode = debugMode;
         setLogger(logger);
     }
 
@@ -47,7 +51,7 @@ public class TextSpecificationBinder implements IBinder {
 
                 mLogger.debug("Creating full binding for " + source + " " + target);
 
-                BindingAssociationEngine bindingAssociationEngine = new BindingAssociationEngine(request, mSourceFactory, mTargetFactory, mLogger);
+                BindingAssociationEngine bindingAssociationEngine = new BindingAssociationEngine(request, mSourceFactory, mTargetFactory, mLogger, mDebugMode);
                 bindings.add(bindingAssociationEngine);
             } else {
                 mLogger.debug("Cannot create binding for " + source + " " + target + ", path is null or empty!");

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/ViewBindingEngine.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/ViewBindingEngine.java
@@ -79,6 +79,9 @@ public class ViewBindingEngine implements IViewBindingEngine {
     public void lazyBindView(View view, Object source) {
         if (source == null) {
             mLogger.error("ViewModel source cannot be null!");
+            if (mDebugMode) {
+                throw new RuntimeException("ViewModel source cannot be null! View = " + view);
+            }
             return;
         }
 

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/ViewBindingEngine.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/ViewBindingEngine.java
@@ -57,7 +57,7 @@ public class ViewBindingEngine implements IViewBindingEngine {
         BindingSpecificationParser bindingParser = new BindingSpecificationParser(mConverterService, mResourceService, getLogger());
         BindingSpecificationListParser listParser = new BindingSpecificationListParser(bindingParser, getLogger());
 
-        mBinder = new TextSpecificationBinder(listParser, sourceFactory, targetFactory, getLogger());
+        mBinder = new TextSpecificationBinder(listParser, sourceFactory, targetFactory, getLogger(), mDebugMode);
     }
 
     @Override

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/ViewBindingEngine.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/ViewBindingEngine.java
@@ -52,8 +52,8 @@ public class ViewBindingEngine implements IViewBindingEngine {
         mConverterService = new ValueConverterService(getLogger());
         mResourceService = new ResourceService(getLogger());
 
-        SourceBindingFactory sourceFactory = new SourceBindingFactory(getLogger());
-        TargetBindingFactory targetFactory = new TargetBindingFactory(getLogger());
+        SourceBindingFactory sourceFactory = new SourceBindingFactory(getLogger(), mDebugMode);
+        TargetBindingFactory targetFactory = new TargetBindingFactory(getLogger(), mDebugMode);
         BindingSpecificationParser bindingParser = new BindingSpecificationParser(mConverterService, mResourceService, getLogger());
         BindingSpecificationListParser listParser = new BindingSpecificationListParser(bindingParser, getLogger());
 

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/ViewBindingEngine.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/ViewBindingEngine.java
@@ -54,7 +54,7 @@ public class ViewBindingEngine implements IViewBindingEngine {
 
         SourceBindingFactory sourceFactory = new SourceBindingFactory(getLogger(), mDebugMode);
         TargetBindingFactory targetFactory = new TargetBindingFactory(getLogger(), mDebugMode);
-        BindingSpecificationParser bindingParser = new BindingSpecificationParser(mConverterService, mResourceService, getLogger());
+        BindingSpecificationParser bindingParser = new BindingSpecificationParser(mConverterService, mResourceService, getLogger(), mDebugMode);
         BindingSpecificationListParser listParser = new BindingSpecificationListParser(bindingParser, getLogger());
 
         mBinder = new TextSpecificationBinder(listParser, sourceFactory, targetFactory, getLogger(), mDebugMode);

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/ViewBindingEngine.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/ViewBindingEngine.java
@@ -34,7 +34,7 @@ public class ViewBindingEngine implements IViewBindingEngine {
 
     private IImageLoader mImageLoader = IImageLoader.nullImageLoader;
 
-    private boolean mDebugMode;
+    private boolean mDebugMode = false;
 
     private ValueConverterService mConverterService;
 
@@ -46,8 +46,9 @@ public class ViewBindingEngine implements IViewBindingEngine {
 
     private Map<View, String> mLazyBoundViews = new ConcurrentHashMap<>();
 
-    public ViewBindingEngine(ILogger logger) {
+    public ViewBindingEngine(ILogger logger, boolean debugMode) {
         setLogger(logger);
+        mDebugMode = debugMode;
         mConverterService = new ValueConverterService(getLogger());
         mResourceService = new ResourceService(getLogger());
 
@@ -212,7 +213,7 @@ public class ViewBindingEngine implements IViewBindingEngine {
 
         mLogger.verbose("clearBindingsFor finished for view = " + view + ", remaining bound views size = " + mBoundViews.size());
 
-        if (isDebugMode()) {
+        if (mDebugMode) {
             for (View remainingview : mBoundViews.keySet()) {
                 if (remainingview.getContext() == view.getContext()) {
                     mLogger.verbose(
@@ -265,10 +266,6 @@ public class ViewBindingEngine implements IViewBindingEngine {
         return mImageLoader;
     }
 
-    public boolean isDebugMode() {
-        return mDebugMode;
-    }
-
     public IBinder getBinder() {
         return mBinder;
     }
@@ -281,7 +278,4 @@ public class ViewBindingEngine implements IViewBindingEngine {
         mImageLoader = imageLoader;
     }
 
-    public void setDebugMode(boolean debugMode) {
-        mDebugMode = debugMode;
-    }
 }

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/BindingBase.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/BindingBase.java
@@ -14,7 +14,7 @@ public abstract class BindingBase implements IBinding, INeedsLogger {
 
     private PublishSubject<Exceptional<Object>> mChanges = PublishSubject.create();
 
-    private Object mSubject;
+    protected Object mSubject;
 
     private ILogger mLogger = NullLogger.instance;
 

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/ChainedBinding.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/ChainedBinding.java
@@ -74,7 +74,11 @@ public class ChainedBinding extends PropertyBinding {
     @Override
     public void setValue(Object value) {
         if (mCurrentBinding == null) {
-            getLogger().warning("Target property path is missing. Couldn't set value for " + mMemberName);
+            String msg = "Target property path is missing. Couldn't set value for " + mMemberName;
+            getLogger().warning(msg);
+            if (mDebugMode) {
+                throw new RuntimeException(msg);
+            }
         } else {
             mCurrentBinding.setValue(value);
         }
@@ -83,7 +87,11 @@ public class ChainedBinding extends PropertyBinding {
     @Override
     public void addValue(Object object) {
         if (mCurrentBinding == null) {
-            getLogger().warning("Target property path is missing. Couldn't set value for " + mMemberName);
+            String msg = "Target property path is missing. Couldn't set value for " + mMemberName;
+            getLogger().warning(msg);
+            if (mDebugMode) {
+                throw new RuntimeException(msg);
+            }
         } else {
             mCurrentBinding.setValue(object);
         }

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/ChainedBinding.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/ChainedBinding.java
@@ -24,8 +24,8 @@ public class ChainedBinding extends PropertyBinding {
     private String mMemberName;
 
     public ChainedBinding(Object source, String propertyName, List<String> tokens, boolean needChangesIfPossible, IBindingFactory factory,
-            ILogger logger) {
-        super(source, propertyName, needChangesIfPossible, logger);
+            ILogger logger, boolean debugMode) {
+        super(source, propertyName, needChangesIfPossible, logger, debugMode);
         mNeedChangesIfPossible = needChangesIfPossible;
         mMemberName = propertyName;
         mTokens = tokens;

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/CommandBinding.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/CommandBinding.java
@@ -9,12 +9,15 @@ import solutions.alterego.androidbound.interfaces.ILogger;
 
 public class CommandBinding extends BindingBase {
 
+    private final boolean mDebugMode;
+
     private ICommand mCommand = ICommand.empty;
 
     private CommandInfo mInfo;
 
-    public CommandBinding(Object subject, String commandName, ILogger logger) {
+    public CommandBinding(Object subject, String commandName, ILogger logger, boolean debugMode) {
         super(subject, logger);
+        mDebugMode = debugMode;
 
         mInfo = Reflector.getCommand(subject.getClass(), commandName);
 
@@ -39,6 +42,9 @@ public class CommandBinding extends BindingBase {
                         return mInfo.check(getSubject(), parameter);
                     } catch (Exception ex) {
                         getLogger().error("Error while checking command " + mInfo.getCommandName() + ": " + ex.getMessage());
+                        if (mDebugMode) {
+                            throw new RuntimeException(ex);
+                        }
                     }
                     return true;
                 }
@@ -49,6 +55,9 @@ public class CommandBinding extends BindingBase {
                         mInfo.invoke(getSubject(), parameter);
                     } catch (Exception ex) {
                         getLogger().error("Error while raising command " + mInfo.getCommandName() + ": " + ex.getMessage());
+                        if (mDebugMode) {
+                            throw new RuntimeException(ex);
+                        }
                     }
                 }
 
@@ -58,6 +67,9 @@ public class CommandBinding extends BindingBase {
                         return mInfo.check(getSubject(), view, parameter);
                     } catch (Exception ex) {
                         getLogger().error("Error while checking command " + mInfo.getCommandName() + ": " + ex.getMessage());
+                        if (mDebugMode) {
+                            throw new RuntimeException(ex);
+                        }
                     }
                     return true;
                 }
@@ -76,7 +88,11 @@ public class CommandBinding extends BindingBase {
                     try {
                         mInfo.invoke(getSubject(), parameter2);
                     } catch (Exception e) {
-                        execute(parameter);
+                        if (mDebugMode) {
+                            throw new RuntimeException(e);
+                        } else {
+                            execute(parameter);
+                        }
                     }
                 }
             };

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/CommandBinding.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/CommandBinding.java
@@ -111,17 +111,29 @@ public class CommandBinding extends BindingBase {
 
     @Override
     public void setValue(Object value) {
-        getLogger().warning("Cannot set value for command " + mInfo.getCommandName());
+        String msg = "Cannot set value for command " + mInfo.getCommandName();
+        getLogger().warning(msg);
+        if (mDebugMode) {
+            throw new RuntimeException(msg);
+        }
     }
 
     @Override
     public void addValue(Object object) {
-        getLogger().warning("Cannot add value for command " + mInfo.getCommandName());
+        String msg = "Cannot add value for command " + mInfo.getCommandName();
+        getLogger().warning(msg);
+        if (mDebugMode) {
+            throw new RuntimeException(msg);
+        }
     }
 
     @Override
     public void removeValue(Object result) {
-        getLogger().warning("Cannot add value for command " + mInfo.getCommandName());
+        String msg = "Cannot remove value for command " + mInfo.getCommandName();
+        getLogger().warning(msg);
+        if (mDebugMode) {
+            throw new RuntimeException(msg);
+        }
     }
 
     @Override

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/CommandBinding.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/CommandBinding.java
@@ -88,11 +88,7 @@ public class CommandBinding extends BindingBase {
                     try {
                         mInfo.invoke(getSubject(), parameter2);
                     } catch (Exception e) {
-                        if (mDebugMode) {
-                            throw new RuntimeException(e);
-                        } else {
-                            execute(parameter);
-                        }
+                        execute(parameter);
                     }
                 }
             };

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/PropertyBinding.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/PropertyBinding.java
@@ -14,10 +14,10 @@ public class PropertyBinding extends BindingBase {
 
     private PropertyInfo mPropertyInfo;
 
-    public PropertyBinding(Object subject, String propertyName, boolean needChangesIfPossible, ILogger logger) {
+    public PropertyBinding(Object subject, String propertyName, boolean needChangesIfPossible, ILogger logger, boolean debugMode) {
         super(subject, logger);
 
-        mPropertyInfo = Reflector.getProperty(subject.getClass(), propertyName, logger);
+        mPropertyInfo = Reflector.getProperty(subject.getClass(), propertyName, logger, debugMode);
         setupBinding(subject, mPropertyInfo.getPropertyName(), needChangesIfPossible);
     }
 

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/PropertyBinding.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/PropertyBinding.java
@@ -70,7 +70,8 @@ public class PropertyBinding extends BindingBase {
             return mPropertyInfo.getValue(getSubject());
         }
 
-        String msg = "Cannot get value for property " + mPropertyInfo.getPropertyName() + ": property is non-existent";
+        String msg = "Cannot get value for property " + mPropertyInfo.getPropertyName() + " of type " + mPropertyInfo.getPropertyType()
+                + ": property is non-existent";
         getLogger().warning(msg);
         if (mDebugMode) {
             throw new RuntimeException(msg);
@@ -86,10 +87,12 @@ public class PropertyBinding extends BindingBase {
             String msg;
 
             if (mPropertyInfo.isCanRead()) {
-                msg = "Cannot set value for property " + mPropertyInfo.getPropertyName() + ": property is read-only";
+                msg = "Cannot set value for property " + mPropertyInfo.getPropertyName() + " of type " + mPropertyInfo.getPropertyType()
+                        + " on object = " + mSubject + ": property is read-only";
                 getLogger().warning(msg);
             } else {
-                msg = "Cannot set value for property " + mPropertyInfo.getPropertyName() + ": property is non-existent";
+                msg = "Cannot set value for property " + mPropertyInfo.getPropertyName() + " of type " + mPropertyInfo.getPropertyType()
+                        + " on object = " + mSubject + ": property is non-existent";
                 getLogger().warning(msg);
             }
             if (mDebugMode) {
@@ -106,10 +109,12 @@ public class PropertyBinding extends BindingBase {
             String msg;
 
             if (mPropertyInfo.isCanRead()) {
-                msg = "Cannot add value for property " + mPropertyInfo.getPropertyName() + ": property is read-only";
+                msg = "Cannot add value for property " + mPropertyInfo.getPropertyName() + " of type " + mPropertyInfo.getPropertyType()
+                        + " on object = " + mSubject + ": property is read-only";
                 getLogger().warning(msg);
             } else {
-                msg = "Cannot add value for property " + mPropertyInfo.getPropertyName() + ": property is non-existent";
+                msg = "Cannot add value for property " + mPropertyInfo.getPropertyName() + " of type " + mPropertyInfo.getPropertyType()
+                        + " on object = " + mSubject + ": property is non-existent";
                 getLogger().warning(msg);
             }
             if (mDebugMode) {
@@ -126,10 +131,12 @@ public class PropertyBinding extends BindingBase {
             String msg;
 
             if (mPropertyInfo.isCanRead()) {
-                msg = "Cannot remove value for property " + mPropertyInfo.getPropertyName() + ": property is read-only";
+                msg = "Cannot remove value for property " + mPropertyInfo.getPropertyName() + " of type " + mPropertyInfo.getPropertyType()
+                        + " on object = " + mSubject + ": property is read-only";
                 getLogger().warning(msg);
             } else {
-                msg = "Cannot remove value for property " + mPropertyInfo.getPropertyName() + ": property is non-existent";
+                msg = "Cannot remove value for property " + mPropertyInfo.getPropertyName() + " of type " + mPropertyInfo.getPropertyType()
+                        + " on object = " + mSubject + ": property is non-existent";
                 getLogger().warning(msg);
             }
             if (mDebugMode) {

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/PropertyBinding.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/PropertyBinding.java
@@ -10,12 +10,15 @@ import solutions.alterego.androidbound.interfaces.ILogger;
 
 public class PropertyBinding extends BindingBase {
 
+    protected final boolean mDebugMode;
+
     private Disposable mMemberDisposable;
 
     private PropertyInfo mPropertyInfo;
 
     public PropertyBinding(Object subject, String propertyName, boolean needChangesIfPossible, ILogger logger, boolean debugMode) {
         super(subject, logger);
+        mDebugMode = debugMode;
 
         mPropertyInfo = Reflector.getProperty(subject.getClass(), propertyName, logger, debugMode);
         setupBinding(subject, mPropertyInfo.getPropertyName(), needChangesIfPossible);
@@ -67,8 +70,11 @@ public class PropertyBinding extends BindingBase {
             return mPropertyInfo.getValue(getSubject());
         }
 
-        getLogger().warning(
-                "Cannot get value for property " + mPropertyInfo.getPropertyName() + ": property is non-existent");
+        String msg = "Cannot get value for property " + mPropertyInfo.getPropertyName() + ": property is non-existent";
+        getLogger().warning(msg);
+        if (mDebugMode) {
+            throw new RuntimeException(msg);
+        }
         return noValue;
     }
 
@@ -77,12 +83,17 @@ public class PropertyBinding extends BindingBase {
         if (mPropertyInfo.isCanWrite()) {
             mPropertyInfo.setValue(getSubject(), value);
         } else {
+            String msg;
+
             if (mPropertyInfo.isCanRead()) {
-                getLogger().warning(
-                        "Cannot set value for property " + mPropertyInfo.getPropertyName() + ": propery is read-only");
+                msg = "Cannot set value for property " + mPropertyInfo.getPropertyName() + ": property is read-only";
+                getLogger().warning(msg);
             } else {
-                getLogger().warning("Cannot set value for property " + mPropertyInfo.getPropertyName()
-                        + ": propery is non-existent");
+                msg = "Cannot set value for property " + mPropertyInfo.getPropertyName() + ": property is non-existent";
+                getLogger().warning(msg);
+            }
+            if (mDebugMode) {
+                throw new RuntimeException(msg);
             }
         }
     }
@@ -92,12 +103,17 @@ public class PropertyBinding extends BindingBase {
         if (mPropertyInfo.isCanAdd()) {
             mPropertyInfo.addValue(getSubject(), object);
         } else {
+            String msg;
+
             if (mPropertyInfo.isCanRead()) {
-                getLogger().warning(
-                        "Cannot add value for property " + mPropertyInfo.getPropertyName() + ": propery is read-only");
+                msg = "Cannot add value for property " + mPropertyInfo.getPropertyName() + ": property is read-only";
+                getLogger().warning(msg);
             } else {
-                getLogger().warning("Cannot add value for property " + mPropertyInfo.getPropertyName()
-                        + ": propery is non-existent");
+                msg = "Cannot add value for property " + mPropertyInfo.getPropertyName() + ": property is non-existent";
+                getLogger().warning(msg);
+            }
+            if (mDebugMode) {
+                throw new RuntimeException(msg);
             }
         }
     }
@@ -107,12 +123,17 @@ public class PropertyBinding extends BindingBase {
         if (mPropertyInfo.isCanRemove()) {
             mPropertyInfo.removeValue(getSubject(), result);
         } else {
+            String msg;
+
             if (mPropertyInfo.isCanRead()) {
-                getLogger().warning(
-                        "Cannot add value for property " + mPropertyInfo.getPropertyName() + ": propery is read-only");
+                msg = "Cannot remove value for property " + mPropertyInfo.getPropertyName() + ": property is read-only";
+                getLogger().warning(msg);
             } else {
-                getLogger().warning("Cannot add value for property " + mPropertyInfo.getPropertyName()
-                        + ": propery is non-existent");
+                msg = "Cannot remove value for property " + mPropertyInfo.getPropertyName() + ": property is non-existent";
+                getLogger().warning(msg);
+            }
+            if (mDebugMode) {
+                throw new RuntimeException(msg);
             }
         }
     }

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/TargetPropertyBinding.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/binding/types/TargetPropertyBinding.java
@@ -9,8 +9,8 @@ public class TargetPropertyBinding extends PropertyBinding {
 
     private String propertyName;
 
-    public TargetPropertyBinding(Object subject, String propertyName, boolean needChangesIfPossible, ILogger logger) {
-        super(subject, propertyName, needChangesIfPossible, logger);
+    public TargetPropertyBinding(Object subject, String propertyName, boolean needChangesIfPossible, ILogger logger, boolean debugMode) {
+        super(subject, propertyName, needChangesIfPossible, logger, debugMode);
         this.propertyName = propertyName;
     }
 

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/factories/SourceBindingFactory.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/factories/SourceBindingFactory.java
@@ -12,9 +12,12 @@ import solutions.alterego.androidbound.interfaces.ILogger;
 
 public class SourceBindingFactory implements IBindingFactory {
 
+    protected final boolean mDebugMode;
+
     protected ILogger mLogger;
 
-    public SourceBindingFactory(ILogger logger) {
+    public SourceBindingFactory(ILogger logger, boolean debugMode) {
+        mDebugMode = debugMode;
         setLogger(logger);
     }
 
@@ -39,14 +42,14 @@ public class SourceBindingFactory implements IBindingFactory {
         if (property.equals("this")) {
             return new SelfBinding(source, mLogger);
         } else if (CommandBinding.isCommand(source, property)) {
-            return new CommandBinding(source, property, mLogger);
+            return new CommandBinding(source, property, mLogger, mDebugMode);
         } else {
-            return new PropertyBinding(source, property, needChangesIfPossible, mLogger);
+            return new PropertyBinding(source, property, needChangesIfPossible, mLogger, mDebugMode);
         }
     }
 
     protected IBinding createChained(Object source, String property, List<String> remainingTokens, boolean needChangesIfPossible) {
-        return new ChainedBinding(source, property, remainingTokens, needChangesIfPossible, this, mLogger);
+        return new ChainedBinding(source, property, remainingTokens, needChangesIfPossible, this, mLogger, mDebugMode);
     }
 
     public void setLogger(ILogger logger) {

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/factories/TargetBindingFactory.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/factories/TargetBindingFactory.java
@@ -6,12 +6,12 @@ import solutions.alterego.androidbound.interfaces.ILogger;
 
 public class TargetBindingFactory extends SourceBindingFactory {
 
-    public TargetBindingFactory(ILogger logger) {
-        super(logger);
+    public TargetBindingFactory(ILogger logger, boolean debugMode) {
+        super(logger, debugMode);
     }
 
     @Override
     protected IBinding createLeaf(Object source, String property, boolean needChangesIfPossible) {
-        return new TargetPropertyBinding(source, property, needChangesIfPossible, mLogger);
+        return new TargetPropertyBinding(source, property, needChangesIfPossible, mLogger, mDebugMode);
     }
 }

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/helpers/Reflector.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/helpers/Reflector.java
@@ -90,7 +90,7 @@ public class Reflector {
         }
     }
 
-    public static PropertyInfo getProperty(Class<?> type, String name, ILogger logger) {
+    public static PropertyInfo getProperty(Class<?> type, String name, ILogger logger, boolean debugMode) {
         MethodInfo propertyGetter = null;
         MethodInfo propertySetter = null;
         MethodInfo propertyAdd = null;
@@ -149,7 +149,8 @@ public class Reflector {
                 propertyAdd,
                 propertyRemove,
                 propertyField,
-                logger);
+                logger,
+                debugMode);
 
         synchronized (mSynchronizedObject) {
             SparseArray<PropertyInfo> sa = mObjectProperties.get(typeCode);

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/helpers/reflector/PropertyInfo.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/helpers/reflector/PropertyInfo.java
@@ -56,7 +56,8 @@ public class PropertyInfo {
             try {
                 result = mGetterMethod != null ? mGetterMethod.getOriginalMethod().invoke(obj) : mField.getFieldOriginal().get(obj);
             } catch (Exception e) {
-                mLogger.error("PropertyInfo getValue exception = " + e.getCause().toString() + " for object = " + obj);
+                mLogger.error("PropertyInfo getValue exception = " + e.getCause().toString() + " for object = " + obj + " using field = " + mField
+                        + " and getter method = " + mGetterMethod);
                 if (mDebugMode) {
                     throw new RuntimeException(e);
                 }
@@ -64,12 +65,10 @@ public class PropertyInfo {
         } else if (obj != null && obj instanceof Map) {
             result = ((Map) obj).get(mPropertyName);
         }
+
         if (result == null) {
-            String msg = "PropertyInfo getValue returns null";
-            mLogger.warning(msg);
-            if (mDebugMode) {
-                throw new RuntimeException(msg);
-            }
+            mLogger.debug(
+                    "PropertyInfo getValue returns null, property name = " + mPropertyName + ", type = " + mPropertyType + " for object = " + obj);
         }
         return result;
     }
@@ -78,11 +77,12 @@ public class PropertyInfo {
         if (mSetterMethod != null) {
             try {
                 mLogger.verbose(
-                        "PropertyInfo setValue value = " + value + " for object = " + obj + " using method = "
-                                + mSetterMethod.getOriginalMethod().getName());
+                        "PropertyInfo setValue value = " + value + " for object = " + obj + " using method = " + mSetterMethod.getOriginalMethod()
+                                .getName());
                 mSetterMethod.getOriginalMethod().invoke(obj, value);
             } catch (Exception e) {
-                mLogger.warning("PropertyInfo couldn't setValue using method, value = " + value + " for object = " + obj);
+                mLogger.warning("PropertyInfo couldn't setValue using method, value = " + value + " for object = " + obj + " using method = "
+                        + mSetterMethod.getOriginalMethod().getName());
                 if (mDebugMode) {
                     throw new RuntimeException(e);
                 }
@@ -90,11 +90,12 @@ public class PropertyInfo {
         } else if (mField != null) {
             try {
                 mLogger.verbose(
-                        "PropertyInfo setValue value = " + value + " for object = " + obj + " using field = "
-                                + mField.getFieldOriginal().getName());
+                        "PropertyInfo setValue value = " + value + " for object = " + obj + " using field = " + mField.getFieldOriginal().getName());
                 mField.getFieldOriginal().set(obj, value);
             } catch (Exception e) {
-                mLogger.warning("PropertyInfo couldn't setValue using property, value = " + value + " for object = " + obj);
+                mLogger.warning(
+                        "PropertyInfo couldn't setValue using property, value = " + value + " for object = " + obj + " using field = " + mField
+                                .getFieldOriginal().getName());
                 if (mDebugMode) {
                     throw new RuntimeException(e);
                 }

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/helpers/reflector/PropertyInfo.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/helpers/reflector/PropertyInfo.java
@@ -23,6 +23,8 @@ public class PropertyInfo {
 
     private final ILogger mLogger;
 
+    private final boolean mDebugMode;
+
     private final MethodInfo mAdder;
 
     private final boolean mCanAdd;
@@ -32,7 +34,7 @@ public class PropertyInfo {
     private final MethodInfo mRemover;
 
     public PropertyInfo(String name, boolean canRead, boolean canWrite, boolean canAdd, boolean canRemove, Class<?> type,
-            MethodInfo getter, MethodInfo setter, MethodInfo adder, MethodInfo remover, FieldInfo field, ILogger logger) {
+            MethodInfo getter, MethodInfo setter, MethodInfo adder, MethodInfo remover, FieldInfo field, ILogger logger, boolean debugMode) {
         mPropertyType = type;
         mPropertyName = name;
         mCanRead = canRead;
@@ -45,6 +47,7 @@ public class PropertyInfo {
         mField = field;
         mAdder = adder;
         mLogger = logger;
+        mDebugMode = debugMode;
     }
 
     public Object getValue(Object obj) {
@@ -54,6 +57,9 @@ public class PropertyInfo {
                 result = mGetterMethod != null ? mGetterMethod.getOriginalMethod().invoke(obj) : mField.getFieldOriginal().get(obj);
             } catch (Exception e) {
                 mLogger.error("PropertyInfo getValue exception = " + e.getCause().toString() + " for object = " + obj);
+                if (mDebugMode) {
+                    throw new RuntimeException(e);
+                }
             }
         } else if (obj != null && obj instanceof Map) {
             result = ((Map) obj).get(mPropertyName);
@@ -98,7 +104,10 @@ public class PropertyInfo {
                                 + " can't be invoked on a field.");
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            mLogger.error("PropertyInfo couldn't addValue using property, value = " + dst + " for object = " + src);
+            if (mDebugMode) {
+                throw new RuntimeException(e);
+            }
         }
     }
 
@@ -108,11 +117,14 @@ public class PropertyInfo {
                 mRemover.getOriginalMethod().invoke(src, dst);
             } else {
                 mLogger.verbose(
-                        "PropertyInfo addValue value = " + dst + " for object = " + src + " using field = "
+                        "PropertyInfo removeValue value = " + dst + " for object = " + src + " using field = "
                                 + " can't be invoked on a field.");
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            mLogger.error("PropertyInfo couldn't removeValue using property, value = " + dst + " for object = " + src);
+            if (mDebugMode) {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/helpers/reflector/PropertyInfo.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/helpers/reflector/PropertyInfo.java
@@ -65,7 +65,11 @@ public class PropertyInfo {
             result = ((Map) obj).get(mPropertyName);
         }
         if (result == null) {
-            mLogger.warning("PropertyInfo getValue returns null");
+            String msg = "PropertyInfo getValue returns null";
+            mLogger.warning(msg);
+            if (mDebugMode) {
+                throw new RuntimeException(msg);
+            }
         }
         return result;
     }
@@ -79,6 +83,9 @@ public class PropertyInfo {
                 mSetterMethod.getOriginalMethod().invoke(obj, value);
             } catch (Exception e) {
                 mLogger.warning("PropertyInfo couldn't setValue using method, value = " + value + " for object = " + obj);
+                if (mDebugMode) {
+                    throw new RuntimeException(e);
+                }
             }
         } else if (mField != null) {
             try {
@@ -88,6 +95,9 @@ public class PropertyInfo {
                 mField.getFieldOriginal().set(obj, value);
             } catch (Exception e) {
                 mLogger.warning("PropertyInfo couldn't setValue using property, value = " + value + " for object = " + obj);
+                if (mDebugMode) {
+                    throw new RuntimeException(e);
+                }
             }
         } else if (obj != null && obj instanceof Map) { //using local map of values
             ((Map) obj).put(mPropertyName, value);

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/interfaces/IHasDebugMode.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/interfaces/IHasDebugMode.java
@@ -1,7 +1,0 @@
-package solutions.alterego.androidbound.interfaces;
-
-public interface IHasDebugMode {
-
-    void setDebugMode(boolean debugMode);
-    
-}

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/interfaces/IViewBinder.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/interfaces/IViewBinder.java
@@ -12,8 +12,7 @@ import solutions.alterego.androidbound.converters.interfaces.IValueConverterProv
 import solutions.alterego.androidbound.resources.interfaces.IResourceRegistry;
 
 
-public interface IViewBinder extends IResourceRegistry, IValueConverterProvider, IDisposable, INeedsImageLoader, IHasLogger, INeedsFontManager,
-        IHasDebugMode {
+public interface IViewBinder extends IResourceRegistry, IValueConverterProvider, IDisposable, INeedsImageLoader, IHasLogger, INeedsFontManager {
 
     void registerViewResolver(IViewResolver resolver);
 
@@ -34,5 +33,7 @@ public interface IViewBinder extends IResourceRegistry, IValueConverterProvider,
     View inflate(Context context, Object source, int layoutResID, ViewGroup viewGroup, IViewResolver additionalResolver);
 
     void disposeOf(Context context);
+
+    boolean isDebugMode();
 
 }

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/interfaces/IViewBindingEngine.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/interfaces/IViewBindingEngine.java
@@ -12,7 +12,7 @@ import solutions.alterego.androidbound.binding.interfaces.IBindingAssociationEng
 import solutions.alterego.androidbound.converters.interfaces.IValueConverterProvider;
 import solutions.alterego.androidbound.resources.interfaces.IResourceRegistry;
 
-public interface IViewBindingEngine extends IDisposable, INeedsImageLoader, IHasImageLoader, IHasLogger, IHasDebugMode, IResourceRegistry,
+public interface IViewBindingEngine extends IDisposable, INeedsImageLoader, IHasImageLoader, IHasLogger, IResourceRegistry,
         IValueConverterProvider {
 
     IBinder getBinder();

--- a/AndroidBound/src/main/java/solutions/alterego/androidbound/parsers/BindingSpecificationParser.java
+++ b/AndroidBound/src/main/java/solutions/alterego/androidbound/parsers/BindingSpecificationParser.java
@@ -30,9 +30,12 @@ public class BindingSpecificationParser implements IParser<BindingSpecification>
 
     private IResourceProvider mResourceProvider;
 
-    public BindingSpecificationParser(IValueConverterProvider converterProvider, IResourceProvider resourceProvider, ILogger logger) {
+    private final boolean mDebugMode;
+
+    public BindingSpecificationParser(IValueConverterProvider converterProvider, IResourceProvider resourceProvider, ILogger logger, boolean debugMode) {
         mValueConverterProvider = converterProvider;
         mResourceProvider = resourceProvider;
+        mDebugMode = debugMode;
         setLogger(logger);
     }
 
@@ -94,7 +97,11 @@ public class BindingSpecificationParser implements IParser<BindingSpecification>
             return BindingMode.RemoveSource;
         }
 
-        mLogger.warning("Invalid value '" + value + "' found for BindingMode. Switching to Default.");
+        String msg = "Invalid value '" + value + "' found for BindingMode. Switching to Default.";
+        mLogger.warning(msg);
+        if (mDebugMode) {
+            throw new RuntimeException(msg);
+        }
         return BindingMode.Default;
     }
 }

--- a/AndroidBound/src/test/kotlin/solutions/alterego/androidbound/parsers/BindingSpecificationListParserTest.java
+++ b/AndroidBound/src/test/kotlin/solutions/alterego/androidbound/parsers/BindingSpecificationListParserTest.java
@@ -50,7 +50,7 @@ public class BindingSpecificationListParserTest {
         ValueConverterService converterService = new ValueConverterService(NullLogger.instance);
         ResourceService resourceService = new ResourceService(NullLogger.instance);
 
-        BindingSpecificationParser bindingParser = new BindingSpecificationParser(converterService, resourceService, NullLogger.instance);
+        BindingSpecificationParser bindingParser = new BindingSpecificationParser(converterService, resourceService, NullLogger.instance, false);
         mListParser = new BindingSpecificationListParser(bindingParser, NullLogger.instance);
     }
 

--- a/AndroidBound/src/test/kotlin/solutions/alterego/androidbound/parsers/BindingSpecificationParserTest.java
+++ b/AndroidBound/src/test/kotlin/solutions/alterego/androidbound/parsers/BindingSpecificationParserTest.java
@@ -64,7 +64,7 @@ public class BindingSpecificationParserTest {
         mValueConverterService = new ValueConverterService(NullLogger.instance);
         ResourceService resourceService = new ResourceService(NullLogger.instance);
 
-        mParser = new BindingSpecificationParser(mValueConverterService, resourceService, NullLogger.instance);
+        mParser = new BindingSpecificationParser(mValueConverterService, resourceService, NullLogger.instance, false);
     }
 
     @Before

--- a/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/ExampleApplication.java
+++ b/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/ExampleApplication.java
@@ -33,8 +33,7 @@ public class ExampleApplication extends Application {
 
         LeakCanary.install(this);
         ILogger logger = new AdvancedAndroidLoggerAdapter(LOGGING_TAG, LOGGING_LEVEL); //use for testing
-        mViewBinder = new SupportViewBinder(this, logger);
-//        mViewBinder.setDebug(true); //use for testing!
+        mViewBinder = new SupportViewBinder(this, logger, true);
         mViewBinder.setImageLoader(new UILImageLoader(this, null));
         mViewBinder.getFontManager().setDefaultFont(Typeface.createFromAsset(getAssets(), "Roboto-Regular.ttf"));
         mViewBinder.getFontManager().registerFont("light", Typeface.createFromAsset(getAssets(), "Roboto-Light.ttf"));

--- a/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/listviewitems/ListViewItem2.java
+++ b/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/listviewitems/ListViewItem2.java
@@ -10,6 +10,10 @@ public class ListViewItem2 {
         mTitle = title;
     }
 
+    public void doImageClicked() {
+        //do nothing
+    }
+
     @Override
     public String toString() {
         return mTitle;

--- a/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/PaginatedViewModel.java
+++ b/AndroidBoundExample-support/src/main/java/solutions/alterego/androidbound/example/support/viewmodels/PaginatedViewModel.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import lombok.experimental.Accessors;
 import solutions.alterego.androidbound.ViewModel;
 import solutions.alterego.androidbound.android.adapters.PageDescriptor;
 import solutions.alterego.androidbound.interfaces.ILogger;
@@ -35,7 +34,6 @@ public class PaginatedViewModel extends ViewModel {
         return this.mRemoveItems;
     }
 
-    @Accessors(prefix = "m")
     public static class RecyclerViewItem {
 
         private String mName;
@@ -110,11 +108,11 @@ public class PaginatedViewModel extends ViewModel {
 
     public PageDescriptor mLoadNextPage2;
 
-    private List<RecyclerViewItem> mDataItems;
+    private List<RecyclerViewItem> mDataItems = new ArrayList<RecyclerViewItem>();
 
-    private List<RecyclerViewItem> mDataItems2;
+    private List<RecyclerViewItem> mDataItems2 = new ArrayList<RecyclerViewItem>();
 
-    private List<RecyclerViewItem> mRemoveItems;
+    private List<RecyclerViewItem> mRemoveItems = new ArrayList<RecyclerViewItem>();
 
     private List<RecyclerViewItem> tmep = new ArrayList<RecyclerViewItem>();
 

--- a/AndroidBoundExample-support/src/main/res/layout/activity_listview_listitem.xml
+++ b/AndroidBoundExample-support/src/main/res/layout/activity_listview_listitem.xml
@@ -13,7 +13,7 @@
             android:layout_width="100dp"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
-            binding="{Source @= ImageUrl}; {Click @- ImageClicked }"
+            binding="{Source @- ImageUrl}; {Click @- ImageClicked }"
             android:layout_margin="4dp"
             android:gravity="left"/>
 
@@ -24,7 +24,7 @@
             android:layout_centerVertical="true"
             android:layout_toRightOf="@+id/image"
             android:layout_toEndOf="@+id/image"
-            binding="{Text @= Title}"
+            binding="{Text @- Title}"
             android:gravity="left"
             android:layout_marginBottom="4dp"
             android:layout_marginLeft="10dp"

--- a/AndroidBoundExample-support/src/main/res/layout/activity_listview_listitem2.xml
+++ b/AndroidBoundExample-support/src/main/res/layout/activity_listview_listitem2.xml
@@ -13,7 +13,7 @@
             android:layout_width="100dp"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
-            binding="{Source @= ImageUrl}"
+            binding="{Source @- ImageUrl}"
             android:layout_margin="4dp"
             android:gravity="left"/>
 
@@ -24,7 +24,7 @@
             android:layout_centerVertical="true"
             android:layout_toRightOf="@+id/image"
             android:layout_toEndOf="@+id/image"
-            binding="{Text @= Title}"
+            binding="{Text @- Title}"
             android:gravity="left"
             android:layout_marginBottom="4dp"
             android:layout_marginLeft="10dp"

--- a/AndroidBoundExample-support/src/main/res/layout/activity_paginated_recyclerview.xml
+++ b/AndroidBoundExample-support/src/main/res/layout/activity_paginated_recyclerview.xml
@@ -40,7 +40,7 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/open_main_activity_button"
                 itemTemplate="@layout/activity_paginated_rv_item"
-                binding="{Items @+@ DataItems2};
+                binding="{ItemsSource @+ DataItems2};
             { RemoveItems !@ RemoveItems};
             { PageDescriptor @= LoadNextPage2 }; { NextPage =@ LoadNextPage2 }; " />
 

--- a/AndroidBoundExample-support/src/main/res/layout/activity_paginated_rv_item.xml
+++ b/AndroidBoundExample-support/src/main/res/layout/activity_paginated_rv_item.xml
@@ -13,7 +13,7 @@
             android:layout_width="100dp"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
-            binding="{Source @= ImageUrl}"
+            binding="{Source @- ImageUrl}"
             android:layout_margin="4dp"
             android:gravity="left"/>
 
@@ -24,7 +24,7 @@
             android:layout_centerVertical="true"
             android:layout_toRightOf="@+id/image"
             android:layout_toEndOf="@+id/image"
-            binding="{Text @= Name}"
+            binding="{Text @- Name}"
             android:gravity="left"
             android:layout_marginBottom="4dp"
             android:layout_marginLeft="10dp"

--- a/AndroidBoundExample-support/src/main/res/layout/nested_rv_item.xml
+++ b/AndroidBoundExample-support/src/main/res/layout/nested_rv_item.xml
@@ -19,7 +19,7 @@
                 android:id="@+id/image"
                 android:layout_width="100dp"
                 android:layout_height="wrap_content"
-                binding="{Source @= ImageUrl}"
+                binding="{Source @- ImageUrl}"
                 android:layout_margin="4dp"
                 android:gravity="left" />
 
@@ -27,7 +27,7 @@
                 android:id="@+id/text"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                binding="{Text @= Name}"
+                binding="{Text @- Name}"
                 android:gravity="left"
                 android:layout_marginBottom="4dp"
                 android:layout_marginLeft="10dp"

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/ExampleApplication.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/ExampleApplication.java
@@ -37,8 +37,7 @@ public class ExampleApplication extends Application {
 
         LeakCanary.install(this);
         ILogger logger = new AdvancedAndroidLoggerAdapter(LOGGING_TAG, LOGGING_LEVEL); //use for testing
-        mViewBinder = new ViewBinder(this, logger);
-//        mViewBinder.setDebug(true); //use for testing!
+        mViewBinder = new ViewBinder(this, logger, true);
         mViewBinder.setImageLoader(new UILImageLoader(this, null));
         mViewBinder.getFontManager().setDefaultFont(Typeface.createFromAsset(getAssets(), "Roboto-Regular.ttf"));
         mViewBinder.getFontManager().registerFont("light", Typeface.createFromAsset(getAssets(), "Roboto-Light.ttf"));

--- a/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/listviewitems/ListViewItem2.java
+++ b/AndroidBoundExample/src/main/java/solutions/alterego/androidbound/example/listviewitems/ListViewItem2.java
@@ -20,4 +20,8 @@ public class ListViewItem2 {
     public String toString() {
         return mTitle;
     }
+
+    public void doImageClicked() {
+        //do nothing
+    }
 }

--- a/AndroidBoundExample/src/main/res/layout/activity_bindable_main.xml
+++ b/AndroidBoundExample/src/main/res/layout/activity_bindable_main.xml
@@ -102,7 +102,7 @@
              { Typeface @- ToFont(this, &apos;italic&apos;) }"/>
 
         <Button
-                binding="{ Click @= ClearEditTextText }"
+                binding="{ Click @- ClearEditTextText }"
                 android:text="clear"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"/>

--- a/AndroidBoundExample/src/main/res/layout/activity_item_detail.xml
+++ b/AndroidBoundExample/src/main/res/layout/activity_item_detail.xml
@@ -13,7 +13,7 @@
             android:layout_width="100dp"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
-            binding="{Source @= ImageUrl}"
+            binding="{Source @- ImageUrl}"
             android:layout_margin="4dp"
             android:gravity="left"/>
 
@@ -24,7 +24,7 @@
             android:layout_centerVertical="true"
             android:layout_toRightOf="@+id/image"
             android:layout_toEndOf="@+id/image"
-            binding="{Text @= Title}"
+            binding="{Text @- Title}"
             android:gravity="left"
             android:layout_marginBottom="4dp"
             android:layout_marginLeft="10dp"

--- a/AndroidBoundExample/src/main/res/layout/activity_listview.xml
+++ b/AndroidBoundExample/src/main/res/layout/activity_listview.xml
@@ -40,6 +40,6 @@
             android:listSelector="@android:color/transparent"
             android:dividerHeight="1dp"
             itemTemplate="@layout/activity_listview_listitem"
-            binding="{Click @- SelectListItem}; {TemplatesForObjects @- LVTemplatesForObjects}; {ItemsSource @= ExampleList}"/>
+            binding="{Click @- SelectListItem}; {ItemsSource @= ExampleList}"/>
 
 </RelativeLayout>

--- a/AndroidBoundExample/src/main/res/layout/activity_listview_listitem.xml
+++ b/AndroidBoundExample/src/main/res/layout/activity_listview_listitem.xml
@@ -13,7 +13,7 @@
             android:layout_width="100dp"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
-            binding="{Source @= ImageUrl}; {Click @- ImageClicked }"
+            binding="{Source @- ImageUrl}; {Click @- ImageClicked }"
             android:layout_margin="4dp"
             android:gravity="left"/>
 
@@ -24,7 +24,7 @@
             android:layout_centerVertical="true"
             android:layout_toRightOf="@+id/image"
             android:layout_toEndOf="@+id/image"
-            binding="{Text @= Title}"
+            binding="{Text @- Title}"
             android:gravity="left"
             android:layout_marginBottom="4dp"
             android:layout_marginLeft="10dp"

--- a/AndroidBoundExample/src/main/res/layout/activity_listview_listitem2.xml
+++ b/AndroidBoundExample/src/main/res/layout/activity_listview_listitem2.xml
@@ -13,7 +13,7 @@
             android:layout_width="100dp"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
-            binding="{Source @= ImageUrl}"
+            binding="{Source @- ImageUrl}"
             android:layout_margin="4dp"
             android:gravity="left"/>
 
@@ -24,7 +24,7 @@
             android:layout_centerVertical="true"
             android:layout_toRightOf="@+id/image"
             android:layout_toEndOf="@+id/image"
-            binding="{Text @= Title}"
+            binding="{Text @- Title}"
             android:gravity="left"
             android:layout_marginBottom="4dp"
             android:layout_marginLeft="10dp"

--- a/androidbound-support/src/main/java/solutions/alterego/androidbound/support/SupportViewBinder.java
+++ b/androidbound-support/src/main/java/solutions/alterego/androidbound/support/SupportViewBinder.java
@@ -12,16 +12,20 @@ import solutions.alterego.androidbound.support.binding.SupportViewBindingEngine;
 public class SupportViewBinder extends ViewBinder {
 
     public SupportViewBinder(Context ctx) {
-        this(ctx, NullLogger.instance);
+        this(ctx, NullLogger.instance, false);
     }
 
     public SupportViewBinder(Context ctx, ILogger logger) {
-        super(ctx, logger);
+        this(ctx, logger, false);
+    }
+
+    public SupportViewBinder(Context ctx, ILogger logger, boolean debugMode) {
+        super(ctx, logger, debugMode);
         registerViewResolver(new SupportViewResolver(logger));
     }
 
     @Override
     protected IViewBindingEngine createViewBindingEngine(ILogger logger) {
-        return new SupportViewBindingEngine(logger);
+        return new SupportViewBindingEngine(logger, isDebugMode());
     }
 }

--- a/androidbound-support/src/main/java/solutions/alterego/androidbound/support/SupportViewBinder.java
+++ b/androidbound-support/src/main/java/solutions/alterego/androidbound/support/SupportViewBinder.java
@@ -21,7 +21,7 @@ public class SupportViewBinder extends ViewBinder {
 
     public SupportViewBinder(Context ctx, ILogger logger, boolean debugMode) {
         super(ctx, logger, debugMode);
-        registerViewResolver(new SupportViewResolver(logger));
+        registerViewResolver(new SupportViewResolver(logger, debugMode));
     }
 
     @Override

--- a/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/BoundSupportActivityDelegate.java
+++ b/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/BoundSupportActivityDelegate.java
@@ -26,11 +26,11 @@ public class BoundSupportActivityDelegate extends BoundActivityDelegate {
     @Override
     public View addViewModel(int layoutResID, ViewModel viewModel, String id) {
         if (getBoundActivity() == null) {
-            throw new RuntimeException("Bound Activity is null!");
+            throw new RuntimeException("Bound Activity is null! ViewModel = " + viewModel);
         }
 
         if (viewModel == null) {
-            throw new RuntimeException("viewModel is null!");
+            throw new RuntimeException("ViewModel is null! Activity = " + getBoundActivity());
         }
 
         if (mViewModels == null) {

--- a/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/BoundSupportFragmentDelegate.java
+++ b/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/BoundSupportFragmentDelegate.java
@@ -82,11 +82,11 @@ public class BoundSupportFragmentDelegate
     @Override
     public View addViewModel(int layoutResID, ViewModel viewModel, String id, @Nullable ViewGroup parent) {
         if (getBoundActivity() == null) {
-            throw new RuntimeException("Bound Activity is null!");
+            throw new RuntimeException("Bound Activity is null! ViewModel = " + viewModel);
         }
 
         if (viewModel == null) {
-            throw new RuntimeException("viewModel is null!");
+            throw new RuntimeException("ViewModel is null! Activity = " + getBoundActivity());
         }
 
         if (mViewModels == null) {

--- a/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/adapters/BindableRecyclerViewAdapter.java
+++ b/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/adapters/BindableRecyclerViewAdapter.java
@@ -70,8 +70,12 @@ public class BindableRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
         } else if (layoutRes != 0) {
             mViewBinder.getLogger().verbose("BindableRecyclerViewAdapter creating VH using layoutRes = " + layoutRes);
         } else {
-            mViewBinder.getLogger().error("BindableRecyclerViewAdapter cannot find templates for class = " + clazz
-                    + ": did you call setTemplatesForObjects or set itemTemplate in XML?");
+            String msg = "BindableRecyclerViewAdapter cannot find templates for class = " + clazz
+                    + ": did you call setTemplatesForObjects or set itemTemplate in XML?";
+            mViewBinder.getLogger().error(msg);
+            if (mViewBinder.isDebugMode()) {
+                throw new RuntimeException(msg);
+            }
         }
         return new BindableRecyclerViewItemViewHolder(
                 mViewBinder.inflate(parent.getContext(), null, layoutRes, parent, false), mViewBinder, parent);

--- a/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/ui/BindableRecyclerView.java
+++ b/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/ui/BindableRecyclerView.java
@@ -266,7 +266,7 @@ public class BindableRecyclerView extends RecyclerView implements IBindableView,
         mAdapter.setItemsSource(value);
     }
 
-    public void addItems(List<?> value) {
+    public void addItemsSource(List<?> value) {
         createAdapterChecked();
         if (getLayoutManager() != null) {
             mAdapter.setLayoutManager(getLayoutManager());
@@ -281,11 +281,7 @@ public class BindableRecyclerView extends RecyclerView implements IBindableView,
     }
 
     public List<?> getRemoveItems() {
-        return getItems();
-    }
-
-    public List<?> getItems() {
-        return mAdapter != null ? mAdapter.getItemsSource() : null;
+        return getItemsSource();
     }
 
     @Override

--- a/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/viewresolvers/SupportViewResolver.java
+++ b/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/viewresolvers/SupportViewResolver.java
@@ -44,7 +44,7 @@ public class SupportViewResolver extends ViewResolver {
     @Override
     protected Class<?> resolveName(String name) {
         if (supportMappings.containsKey(name)) {
-            logger.debug("Resolved " + name);
+            logger.debug(getClass().getSimpleName() + " mapping " + name + " to " + supportMappings.get(name));
             return supportMappings.get(name);
         } else {
             return null;

--- a/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/viewresolvers/SupportViewResolver.java
+++ b/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/viewresolvers/SupportViewResolver.java
@@ -37,8 +37,8 @@ public class SupportViewResolver extends ViewResolver {
         }
     };
 
-    public SupportViewResolver(ILogger logger) {
-        super(logger);
+    public SupportViewResolver(ILogger logger, boolean debugMode) {
+        super(logger, debugMode);
     }
 
     @Override

--- a/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/viewresolvers/SupportViewResolver.java
+++ b/androidbound-support/src/main/java/solutions/alterego/androidbound/support/android/viewresolvers/SupportViewResolver.java
@@ -44,7 +44,7 @@ public class SupportViewResolver extends ViewResolver {
     @Override
     protected Class<?> resolveName(String name) {
         if (supportMappings.containsKey(name)) {
-            logger.debug(getClass().getSimpleName() + " mapping " + name + " to " + supportMappings.get(name));
+            logger.debug(mLoggingTag + " mapping " + name + " to " + supportMappings.get(name));
             return supportMappings.get(name);
         } else {
             return null;

--- a/androidbound-support/src/main/java/solutions/alterego/androidbound/support/binding/SupportViewBindingEngine.java
+++ b/androidbound-support/src/main/java/solutions/alterego/androidbound/support/binding/SupportViewBindingEngine.java
@@ -13,8 +13,8 @@ import solutions.alterego.androidbound.interfaces.ILogger;
 
 public class SupportViewBindingEngine extends ViewBindingEngine {
 
-    public SupportViewBindingEngine(ILogger logger) {
-        super(logger);
+    public SupportViewBindingEngine(ILogger logger, boolean debugMode) {
+        super(logger, debugMode);
     }
 
     @Override


### PR DESCRIPTION
This uses debug mode which was only partially implemented. It's now passed as a parameter to the `ViewBinder` constructor and is used by classes below. If `debugMode` is set to `true`, all exceptions will be logged and rethrown.

Implements https://github.com/alter-ego/androidbound/issues/157 and https://github.com/alter-ego/androidbound/issues/160.